### PR TITLE
rewrite the train, evaluate, and test utility alongisde with ModelBase

### DIFF
--- a/project_playground.ipynb
+++ b/project_playground.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "optimum-cargo",
+   "id": "graduate-sunglasses",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "rising-fishing",
+   "id": "viral-washer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "technological-amendment",
+   "id": "legitimate-yacht",
    "metadata": {},
    "outputs": [
     {
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "material-injury",
+   "id": "impossible-preliminary",
    "metadata": {},
    "outputs": [
     {
@@ -242,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "twelve-phone",
+   "id": "blank-finish",
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "challenging-honey",
+   "id": "typical-three",
    "metadata": {},
    "outputs": [
     {
@@ -296,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "portable-genealogy",
+   "id": "aboriginal-concert",
    "metadata": {},
    "outputs": [
     {
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "unique-lover",
+   "id": "extended-brazilian",
    "metadata": {},
    "outputs": [
     {
@@ -348,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "activated-kinase",
+   "id": "educated-yorkshire",
    "metadata": {},
    "outputs": [
     {
@@ -382,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "loving-reading",
+   "id": "pressed-utility",
    "metadata": {},
    "outputs": [
     {
@@ -405,7 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "affiliated-clothing",
+   "id": "specific-advisory",
    "metadata": {},
    "outputs": [
     {
@@ -460,7 +460,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "bright-malpractice",
+   "id": "charged-combining",
    "metadata": {},
    "outputs": [
     {
@@ -604,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "removed-superintendent",
+   "id": "industrial-cherry",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "quick-enzyme",
+   "id": "clinical-mauritius",
    "metadata": {},
    "outputs": [
     {
@@ -662,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "speaking-procurement",
+   "id": "stuck-distribution",
    "metadata": {},
    "outputs": [
     {
@@ -685,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "going-fishing",
+   "id": "living-little",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "billion-comfort",
+   "id": "floppy-replica",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "hindu-leader",
+   "id": "acceptable-september",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -752,7 +752,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "artistic-choir",
+   "id": "other-china",
    "metadata": {},
    "outputs": [
     {
@@ -778,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "identified-affair",
+   "id": "compound-string",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -795,258 +795,580 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "sudden-selling",
+   "id": "applied-orchestra",
    "metadata": {},
    "outputs": [],
    "source": [
-    "class BaselineModel(nn.Module):\n",
+    "def accuracy(outputs, labels):\n",
+    "    _, preds = torch.max(outputs, dim=1)\n",
+    "    return torch.tensor(torch.sum(preds == labels).item()/len(preds))\n",
+    "\n",
+    "class ModelBase(nn.Module):\n",
+    "    def training_step(self, batch):\n",
+    "        images, labels = batch\n",
+    "        out = self(images)                  # Generate predictions\n",
+    "        loss = F.cross_entropy(out, labels) # Calculate loss\n",
+    "        return loss\n",
     "    \n",
-    "    def __init__(self):\n",
-    "        super(BaselineModel, self).__init__()\n",
+    "    def validation_step(self, batch):\n",
+    "        images, labels = batch\n",
+    "        out = self(images)                    # Generate predictions\n",
+    "        loss = F.cross_entropy(out, labels)   # Calculate loss\n",
+    "        acc = accuracy(out, labels)           # Calculate accuracy\n",
+    "        return {'val_loss': loss.detach(), 'val_acc': acc}\n",
+    "    \n",
+    "    def test_step(self, batch):\n",
+    "        images, labels = batch\n",
+    "        out = self(images)                    # Generate predictions\n",
+    "        loss = F.cross_entropy(out, labels)   # Calculate loss\n",
+    "        return loss\n",
     "        \n",
-    "        self.conv1 = nn.Conv2d(3, 128, kernel_size=3, padding=1)\n",
-    "        self.conv2 = nn.Conv2d(128, 256, kernel_size=3, padding=1)\n",
-    "        self.conv3 = nn.Conv2d(256, 512, kernel_size=3, padding=1)\n",
-    "        self.conv4 = nn.Conv2d(512, 1024, kernel_size=3, padding=1)\n",
-    "        self.conv5 = nn.Conv2d(1024, 2048, kernel_size=3, padding=1)\n",
-    "        \n",
-    "        self.pool = nn.MaxPool2d(2,2)\n",
-    "        self.flatten = nn.Flatten()\n",
-    "        self.relu = nn.ReLU()\n",
-    "        \n",
-    "        self.linear1 = nn.Linear(2048*4*4, 512)\n",
-    "        self.linear2 = nn.Linear(512, 128)\n",
-    "        self.linear3 = nn.Linear(128, 4)\n",
-    "        \n",
-    "    def forward(self, x):\n",
-    "        x = F.relu(self.conv1(x))\n",
-    "        x = self.pool(x)\n",
-    "        x = F.relu(self.conv2(x))\n",
-    "        x = self.pool(x)\n",
-    "        x = F.relu(self.conv3(x))\n",
-    "        x = self.pool(x)\n",
-    "        x = F.relu(self.conv4(x))\n",
-    "        x = self.pool(x)\n",
-    "        x = F.relu(self.conv5(x))\n",
-    "        x = self.pool(x)\n",
-    "#         print(x.shape)\n",
-    "        \n",
-    "        x = self.flatten(x)\n",
-    "#         print(x.shape)\n",
-    "        x = F.relu(self.linear1(x))\n",
-    "        x = F.relu(self.linear2(x))\n",
-    "        out = F.relu(self.linear3(x))\n",
-    "        \n",
-    "        return out"
+    "    def validation_epoch_end(self, outputs):\n",
+    "        batch_losses = [x['val_loss'] for x in outputs]\n",
+    "        epoch_loss = torch.stack(batch_losses).mean()   # Combine losses\n",
+    "        batch_accs = [x['val_acc'] for x in outputs]\n",
+    "        epoch_acc = torch.stack(batch_accs).mean()      # Combine accuracies\n",
+    "        return {'val_loss': epoch_loss.item(), 'val_acc': epoch_acc.item()}\n",
+    "    \n",
+    "    def epoch_end(self, epoch, result):\n",
+    "        print(\"Epoch #{}: train_loss= {:.4f} | val_loss= {:.4f} | val_acc: {:.4f}\".format(\n",
+    "            epoch, result['train_loss'], result['val_loss'], result['val_acc']))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "flexible-bread",
+   "id": "level-silly",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "BaselineModel(\n",
-       "  (conv1): Conv2d(3, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv2): Conv2d(128, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv3): Conv2d(256, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv4): Conv2d(512, 1024, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv5): Conv2d(1024, 2048, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (pool): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-       "  (flatten): Flatten()\n",
-       "  (relu): ReLU()\n",
-       "  (linear1): Linear(in_features=32768, out_features=512, bias=True)\n",
-       "  (linear2): Linear(in_features=512, out_features=128, bias=True)\n",
-       "  (linear3): Linear(in_features=128, out_features=4, bias=True)\n",
-       ")"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "base = BaselineModel()\n",
-    "base"
+    "# class BaselineModel(ModelBase):\n",
+    "    \n",
+    "#     def __init__(self):\n",
+    "#         super(BaselineModel, self).__init__()\n",
+    "        \n",
+    "#         self.conv1 = nn.Conv2d(3, 128, kernel_size=3, padding=1)\n",
+    "#         self.conv2 = nn.Conv2d(128, 256, kernel_size=3, padding=1)\n",
+    "#         self.conv3 = nn.Conv2d(256, 512, kernel_size=3, padding=1)\n",
+    "#         self.conv4 = nn.Conv2d(512, 1024, kernel_size=3, padding=1)\n",
+    "#         self.conv5 = nn.Conv2d(1024, 2048, kernel_size=3, padding=1)\n",
+    "        \n",
+    "#         self.pool = nn.MaxPool2d(2,2)\n",
+    "#         self.flatten = nn.Flatten()\n",
+    "#         self.relu = nn.ReLU()\n",
+    "        \n",
+    "#         self.linear1 = nn.Linear(2048*4*4, 512)\n",
+    "#         self.linear2 = nn.Linear(512, 128)\n",
+    "#         self.linear3 = nn.Linear(128, 4)\n",
+    "        \n",
+    "#     def forward(self, x):\n",
+    "#         x = F.relu(self.conv1(x))\n",
+    "#         x = self.pool(x)\n",
+    "#         x = F.relu(self.conv2(x))\n",
+    "#         x = self.pool(x)\n",
+    "#         x = F.relu(self.conv3(x))\n",
+    "#         x = self.pool(x)\n",
+    "#         x = F.relu(self.conv4(x))\n",
+    "#         x = self.pool(x)\n",
+    "#         x = F.relu(self.conv5(x))\n",
+    "#         x = self.pool(x)\n",
+    "# #         print(x.shape)\n",
+    "        \n",
+    "#         x = self.flatten(x)\n",
+    "# #         print(x.shape)\n",
+    "#         x = F.relu(self.linear1(x))\n",
+    "#         x = F.relu(self.linear2(x))\n",
+    "#         out = F.relu(self.linear3(x))\n",
+    "        \n",
+    "#         return out"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "surprising-antibody",
+   "id": "equivalent-stranger",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def train(num_epochs, train_loader, val_loader, model, optimizer, criterion, use_cuda, save_path=''):\n",
-    "    for i in range(num_epochs):\n",
-    "        training_loss = 0.0\n",
-    "        val_loss = 0.0\n",
+    "def conv_block(in_channels, out_channels, pool=False):\n",
+    "    layers = [nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1), \n",
+    "              nn.BatchNorm2d(out_channels), \n",
+    "              nn.ReLU(inplace=True)]\n",
+    "    if pool: layers.append(nn.MaxPool2d(2))\n",
+    "    return nn.Sequential(*layers)\n",
+    "\n",
+    "class ResNet9(ModelBase):\n",
+    "    def __init__(self, in_channels, num_classes):\n",
+    "        super(ResNet9, self).__init__()\n",
     "        \n",
-    "        # training phase\n",
-    "        model.train()\n",
-    "        for batch, (data, lbl) in enumerate(train_loader):\n",
-    "#             data = data.to(torch.float32)\n",
-    "#             lbl = lbl.to(torch.long)\n",
-    "            if use_cuda:\n",
-    "                data, lbl = data.cuda(), lbl.cuda()\n",
-    "                \n",
-    "            optimizer.zero_grad()\n",
-    "            \n",
-    "            output = model(data)\n",
-    "            loss = criterion(output, lbl)\n",
-    "            loss.backward()\n",
-    "            optimizer.step()\n",
-    "            \n",
-    "            training_loss = training_loss + ((1/(batch+1)) * (loss.data - training_loss))\n",
+    "        self.conv1 = conv_block(in_channels, 64)\n",
+    "        self.conv2 = conv_block(64, 128, pool=True)\n",
+    "        self.res1 = nn.Sequential(conv_block(128, 128), conv_block(128, 128))\n",
     "        \n",
-    "        # evaluation phase\n",
-    "        model.eval()\n",
-    "        for batch, (data, lbl) in enumerate(val_loader):\n",
-    "            if use_cuda:\n",
-    "                data, lbl = data.cuda(), lbl.cuda()\n",
-    "                \n",
-    "            output = model(data)\n",
-    "            loss = criterion(output, lbl)\n",
-    "            \n",
-    "            val_loss += loss.item()\n",
+    "        self.conv3 = conv_block(128, 256, pool=True)\n",
+    "        self.conv4 = conv_block(256, 512, pool=True)\n",
+    "        self.res2 = nn.Sequential(conv_block(512, 512), conv_block(512, 512))\n",
     "        \n",
-    "        print('Epoch #{}: Training loss={} | Validation loss={}'.format(i+1, training_loss, val_loss))\n",
-    "    \n",
-    "    if len(save_path) > 0:\n",
-    "        torch.save(model.state_dict(), save_path)\n",
-    "    \n",
-    "    return model"
+    "        self.classifier = nn.Sequential(nn.MaxPool2d(16), \n",
+    "                                        nn.Flatten(), \n",
+    "                                        nn.Linear(512, num_classes))\n",
+    "        \n",
+    "    def forward(self, xb):\n",
+    "        out = self.conv1(xb)\n",
+    "        out = self.conv2(out)\n",
+    "        out = self.res1(out) + out\n",
+    "        out = self.conv3(out)\n",
+    "        out = self.conv4(out)\n",
+    "        out = self.res2(out) + out\n",
+    "        out = self.classifier(out)\n",
+    "        return out"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "straight-jenny",
+   "id": "scientific-agreement",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ResNet9(\n",
+       "  (conv1): Sequential(\n",
+       "    (0): Conv2d(3, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (2): ReLU(inplace=True)\n",
+       "  )\n",
+       "  (conv2): Sequential(\n",
+       "    (0): Conv2d(64, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (2): ReLU(inplace=True)\n",
+       "    (3): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "  )\n",
+       "  (res1): Sequential(\n",
+       "    (0): Sequential(\n",
+       "      (0): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "      (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "      (2): ReLU(inplace=True)\n",
+       "    )\n",
+       "    (1): Sequential(\n",
+       "      (0): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "      (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "      (2): ReLU(inplace=True)\n",
+       "    )\n",
+       "  )\n",
+       "  (conv3): Sequential(\n",
+       "    (0): Conv2d(128, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (2): ReLU(inplace=True)\n",
+       "    (3): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "  )\n",
+       "  (conv4): Sequential(\n",
+       "    (0): Conv2d(256, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (2): ReLU(inplace=True)\n",
+       "    (3): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "  )\n",
+       "  (res2): Sequential(\n",
+       "    (0): Sequential(\n",
+       "      (0): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "      (1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "      (2): ReLU(inplace=True)\n",
+       "    )\n",
+       "    (1): Sequential(\n",
+       "      (0): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "      (1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "      (2): ReLU(inplace=True)\n",
+       "    )\n",
+       "  )\n",
+       "  (classifier): Sequential(\n",
+       "    (0): MaxPool2d(kernel_size=16, stride=16, padding=0, dilation=1, ceil_mode=False)\n",
+       "    (1): Flatten()\n",
+       "    (2): Linear(in_features=512, out_features=4, bias=True)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "use_cuda = torch.cuda.is_available()\n",
-    "if use_cuda:\n",
-    "    base = base.cuda()\n",
-    "\n",
-    "criterion = nn.CrossEntropyLoss()\n",
-    "optimizer = torch.optim.Adam(base.parameters(), lr=1e-2, weight_decay=0.1)"
+    "resnet9 = ResNet9(3, 4)\n",
+    "resnet9"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "desperate-edition",
+   "id": "eastern-suffering",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_default_device():\n",
+    "    \"\"\"Pick GPU if available, else CPU\"\"\"\n",
+    "    if torch.cuda.is_available():\n",
+    "        return torch.device('cuda')\n",
+    "    else:\n",
+    "        return torch.device('cpu')\n",
+    "    \n",
+    "def to_device(data, device):\n",
+    "    \"\"\"Move tensor(s) to chosen device\"\"\"\n",
+    "    if isinstance(data, (list,tuple)):\n",
+    "        return [to_device(x, device) for x in data]\n",
+    "    return data.to(device, non_blocking=True)\n",
+    "\n",
+    "class DeviceDataLoader():\n",
+    "    \"\"\"Wrap a dataloader to move data to a device\"\"\"\n",
+    "    def __init__(self, dl, device):\n",
+    "        self.dl = dl\n",
+    "        self.device = device\n",
+    "        \n",
+    "    def __iter__(self):\n",
+    "        \"\"\"Yield a batch of data after moving it to device\"\"\"\n",
+    "        for b in self.dl: \n",
+    "            yield to_device(b, self.device)\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        \"\"\"Number of batches\"\"\"\n",
+    "        return len(self.dl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "first-olympus",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "device(type='cuda')"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "device = get_default_device()\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "orange-insert",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loader = DeviceDataLoader(train_loader, device)\n",
+    "valid_loader = DeviceDataLoader(valid_loader, device)\n",
+    "test_loader = DeviceDataLoader(test_loader, device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "precise-television",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@torch.no_grad()\n",
+    "def evaluate(model, val_loader):\n",
+    "    model.eval()\n",
+    "    outputs = [model.validation_step(batch) for batch in val_loader]\n",
+    "    \n",
+    "    return model.validation_epoch_end(outputs)\n",
+    "\n",
+    "def get_lr(optimizer):\n",
+    "    for param_group in optimizer.param_groups:\n",
+    "        return param_group['lr']\n",
+    "\n",
+    "def train(num_epochs, max_lr, train_loader, val_loader, model,\n",
+    "          weight_decay=0, grad_clip=None, opt_func=torch.optim.SGD, save_path=''):\n",
+    "    \n",
+    "    torch.cuda.empty_cache()\n",
+    "    history = []\n",
+    "    \n",
+    "    optimizer = opt_func(model.parameters(), lr=max_lr, weight_decay=weight_decay)\n",
+    "    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr, epochs=num_epochs, steps_per_epoch=len(train_loader))\n",
+    "    \n",
+    "    for i in range(num_epochs):\n",
+    "        training_loss = 0.0\n",
+    "        val_loss = 0.0\n",
+    "        train_losses = []\n",
+    "        lrs = []\n",
+    "        \n",
+    "        # training phase\n",
+    "        model.train()\n",
+    "        for batch in train_loader:\n",
+    "#             data = data.to(torch.float32)\n",
+    "#             lbl = lbl.to(torch.long)\n",
+    "#             if use_cuda:\n",
+    "#                 data, lbl = data.cuda(), lbl.cuda()\n",
+    "            \n",
+    "            loss = model.training_step(batch)\n",
+    "            train_losses.append(loss)\n",
+    "            loss.backward()\n",
+    "            \n",
+    "            if grad_clip:\n",
+    "                nn.utils.clip_grad_value_(model.parameters(), grad_clip)\n",
+    "            \n",
+    "            optimizer.step()\n",
+    "            optimizer.zero_grad()\n",
+    "            \n",
+    "            lrs.append(get_lr(optimizer))\n",
+    "            scheduler.step()\n",
+    "            \n",
+    "#             training_loss = training_loss + ((1/(batch+1)) * (loss.data - training_loss))\n",
+    "        \n",
+    "        # evaluation phase\n",
+    "        result = evaluate(model, val_loader)\n",
+    "        result['train_loss'] = torch.stack(train_losses).mean().item()\n",
+    "        result['lrs'] = lrs\n",
+    "        \n",
+    "        model.epoch_end(i+1, result)\n",
+    "        history.append(result)\n",
+    "    \n",
+    "    if len(save_path) > 0:\n",
+    "        torch.save(model.state_dict(), save_path)\n",
+    "    \n",
+    "    return history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "secret-worse",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = to_device(ResNet9(3, 4), device)\n",
+    "\n",
+    "num_epochs = 20\n",
+    "lr = 1e-2\n",
+    "grad_clip = 0.1\n",
+    "weight_decay = 1e-4\n",
+    "optimizer = torch.optim.Adam"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "balanced-style",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'val_loss': 1.3974016904830933, 'val_acc': 0.25318285822868347}]"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "history = [evaluate(model, valid_loader)]\n",
+    "history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "continuing-construction",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch #1: Training loss=2.1231114864349365 | Validation loss=25.009342432022095\n",
-      "Epoch #2: Training loss=1.2587615251541138 | Validation loss=24.33013355731964\n",
-      "Epoch #3: Training loss=1.2370538711547852 | Validation loss=24.177753806114197\n",
-      "Epoch #4: Training loss=1.2354224920272827 | Validation loss=24.182435750961304\n",
-      "Epoch #5: Training loss=1.2359079122543335 | Validation loss=24.19258737564087\n"
+      "Epoch #1: train_loss= 0.8412 | val_loss= 0.8201 | val_acc: 0.6805\n",
+      "Epoch #2: train_loss= 0.7048 | val_loss= 0.8222 | val_acc: 0.6734\n",
+      "Epoch #3: train_loss= 0.7636 | val_loss= 1.8026 | val_acc: 0.5016\n",
+      "Epoch #4: train_loss= 0.7828 | val_loss= 2.2593 | val_acc: 0.2661\n",
+      "Epoch #5: train_loss= 0.7779 | val_loss= 2.3755 | val_acc: 0.3300\n",
+      "Epoch #6: train_loss= 0.8236 | val_loss= 0.7307 | val_acc: 0.7136\n",
+      "Epoch #7: train_loss= 0.6262 | val_loss= 0.7451 | val_acc: 0.7027\n",
+      "Epoch #8: train_loss= 0.5886 | val_loss= 0.8843 | val_acc: 0.6789\n",
+      "Epoch #9: train_loss= 0.5196 | val_loss= 0.6138 | val_acc: 0.7605\n",
+      "Epoch #10: train_loss= 0.5209 | val_loss= 0.6601 | val_acc: 0.7488\n",
+      "Epoch #11: train_loss= 0.4707 | val_loss= 0.7218 | val_acc: 0.7407\n",
+      "Epoch #12: train_loss= 0.4428 | val_loss= 0.6101 | val_acc: 0.7629\n",
+      "Epoch #13: train_loss= 0.4193 | val_loss= 0.5851 | val_acc: 0.7629\n",
+      "Epoch #14: train_loss= 0.3951 | val_loss= 0.5375 | val_acc: 0.7910\n",
+      "Epoch #15: train_loss= 0.3457 | val_loss= 0.5055 | val_acc: 0.7983\n",
+      "Epoch #16: train_loss= 0.2864 | val_loss= 0.5170 | val_acc: 0.7858\n",
+      "Epoch #17: train_loss= 0.2371 | val_loss= 0.5471 | val_acc: 0.7764\n",
+      "Epoch #18: train_loss= 0.1727 | val_loss= 0.5021 | val_acc: 0.8045\n",
+      "Epoch #19: train_loss= 0.1252 | val_loss= 0.4880 | val_acc: 0.8139\n",
+      "Epoch #20: train_loss= 0.0891 | val_loss= 0.4809 | val_acc: 0.8248\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "BaselineModel(\n",
-       "  (conv1): Conv2d(3, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv2): Conv2d(128, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv3): Conv2d(256, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv4): Conv2d(512, 1024, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (conv5): Conv2d(1024, 2048, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (pool): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-       "  (flatten): Flatten()\n",
-       "  (relu): ReLU()\n",
-       "  (linear1): Linear(in_features=32768, out_features=512, bias=True)\n",
-       "  (linear2): Linear(in_features=512, out_features=128, bias=True)\n",
-       "  (linear3): Linear(in_features=128, out_features=4, bias=True)\n",
-       ")"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "train(5, train_loader, valid_loader, base, optimizer, criterion, use_cuda)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "incomplete-prescription",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "torch.cuda.empty_cache()"
+    "history += train(num_epochs, lr, train_loader, valid_loader, model, \n",
+    "                grad_clip=grad_clip, \n",
+    "                weight_decay=weight_decay, \n",
+    "                opt_func=optimizer)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "affected-arena",
+   "id": "fundamental-executive",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def test(model, test_loader, criterion, use_cuda):\n",
-    "    \n",
-    "    model.eval()\n",
-    "    \n",
-    "    test_loss = 0.0\n",
-    "    for batch, (data, lbl) in enumerate(test_loader):\n",
-    "        if use_cuda:\n",
-    "            data, lbl = data.cuda(), lbl.cuda()\n",
-    "            \n",
-    "        output = model(data)\n",
-    "        loss = criterion(output, lbl)\n",
-    "        test_loss += loss\n",
-    "        \n",
-    "    print('Test loss={}'.format(test_loss))\n",
-    "        "
+    "torch.save(model.state_dict(), 'resnet9.pth')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "portuguese-armor",
+   "execution_count": 33,
+   "id": "verbal-dining",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_accuracies(history):\n",
+    "    accuracies = [x['val_acc'] for x in history]\n",
+    "    plt.plot(accuracies, '-x')\n",
+    "    plt.xlabel('epoch')\n",
+    "    plt.ylabel('accuracy')\n",
+    "    plt.title('Accuracy vs. No. of epochs');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "declared-invalid",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_losses(history):\n",
+    "    train_losses = [x.get('train_loss') for x in history]\n",
+    "    val_losses = [x['val_loss'] for x in history]\n",
+    "    plt.plot(train_losses, '-bx')\n",
+    "    plt.plot(val_losses, '-rx')\n",
+    "    plt.xlabel('epoch')\n",
+    "    plt.ylabel('loss')\n",
+    "    plt.legend(['Training', 'Validation'])\n",
+    "    plt.title('Loss vs. No. of epochs');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "beginning-atmosphere",
    "metadata": {},
    "outputs": [
     {
-     "ename": "RuntimeError",
-     "evalue": "CUDA out of memory. Tried to allocate 256.00 MiB (GPU 0; 8.00 GiB total capacity; 5.99 GiB already allocated; 179.44 MiB free; 6.08 GiB reserved in total by PyTorch)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-30-1c5e99969b4b>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mtest\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mbase\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtest_loader\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcriterion\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0muse_cuda\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m<ipython-input-29-23329a5e5d22>\u001b[0m in \u001b[0;36mtest\u001b[1;34m(model, test_loader, criterion, use_cuda)\u001b[0m\n\u001b[0;32m      8\u001b[0m             \u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlbl\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdata\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcuda\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlbl\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcuda\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      9\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 10\u001b[1;33m         \u001b[0moutput\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mmodel\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     11\u001b[0m         \u001b[0mloss\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcriterion\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0moutput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlbl\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     12\u001b[0m         \u001b[0mtest_loss\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[0mloss\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\envs\\machine-learning\\lib\\site-packages\\torch\\nn\\modules\\module.py\u001b[0m in \u001b[0;36m_call_impl\u001b[1;34m(self, *input, **kwargs)\u001b[0m\n\u001b[0;32m    720\u001b[0m             \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_slow_forward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0minput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    721\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 722\u001b[1;33m             \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0minput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    723\u001b[0m         for hook in itertools.chain(\n\u001b[0;32m    724\u001b[0m                 \u001b[0m_global_forward_hooks\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m<ipython-input-21-e5d8a990c5aa>\u001b[0m in \u001b[0;36mforward\u001b[1;34m(self, x)\u001b[0m\n\u001b[0;32m     19\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     20\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mforward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 21\u001b[1;33m         \u001b[0mx\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mF\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrelu\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mconv1\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     22\u001b[0m         \u001b[0mx\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpool\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     23\u001b[0m         \u001b[0mx\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mF\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mrelu\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mconv2\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\envs\\machine-learning\\lib\\site-packages\\torch\\nn\\modules\\module.py\u001b[0m in \u001b[0;36m_call_impl\u001b[1;34m(self, *input, **kwargs)\u001b[0m\n\u001b[0;32m    720\u001b[0m             \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_slow_forward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0minput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    721\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 722\u001b[1;33m             \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mforward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0minput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    723\u001b[0m         for hook in itertools.chain(\n\u001b[0;32m    724\u001b[0m                 \u001b[0m_global_forward_hooks\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\envs\\machine-learning\\lib\\site-packages\\torch\\nn\\modules\\conv.py\u001b[0m in \u001b[0;36mforward\u001b[1;34m(self, input)\u001b[0m\n\u001b[0;32m    417\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    418\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0mforward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0minput\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mTensor\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m->\u001b[0m \u001b[0mTensor\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 419\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_conv_forward\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0minput\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mweight\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    420\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    421\u001b[0m \u001b[1;32mclass\u001b[0m \u001b[0mConv3d\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0m_ConvNd\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m~\\anaconda3\\envs\\machine-learning\\lib\\site-packages\\torch\\nn\\modules\\conv.py\u001b[0m in \u001b[0;36m_conv_forward\u001b[1;34m(self, input, weight)\u001b[0m\n\u001b[0;32m    413\u001b[0m                             \u001b[0mweight\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mbias\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstride\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    414\u001b[0m                             _pair(0), self.dilation, self.groups)\n\u001b[1;32m--> 415\u001b[1;33m         return F.conv2d(input, weight, self.bias, self.stride,\n\u001b[0m\u001b[0;32m    416\u001b[0m                         self.padding, self.dilation, self.groups)\n\u001b[0;32m    417\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mRuntimeError\u001b[0m: CUDA out of memory. Tried to allocate 256.00 MiB (GPU 0; 8.00 GiB total capacity; 5.99 GiB already allocated; 179.44 MiB free; 6.08 GiB reserved in total by PyTorch)"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA6mUlEQVR4nO3dd3xUddb48c8hNCUgCAEhqGADRaQFUFAkVkSMDVCsiA3bWteOuq7+nkd0fSyruCLY1gJ2RAQpcW2rUtQoTUFRIwgI0gQEkvP748yQIWSSSTI95/16zWtm7tzynTvJPffbRVVxzjlXc9VKdAKcc84llgcC55yr4TwQOOdcDeeBwDnnajgPBM45V8N5IHDOuRrOA4FzSUREWojIByKyXkT+kej0AIjIEhE5JtHpcLHjgcBFRTpdLETkLhFRERkUsqx2YFmbGB/+EuA3oJGqXh/jYzkHeCBwLpzVwN0ikhHn4+4NzFPv6eniyAOBiykRqSciD4nI0sDjIRGpF/ismYhMFJE1IrJaRD4UkVqBz24SkV8CRSQLReToMvZ9qIj8GnqxFpFTRaQg8LqHiMwSkXUislxEHqxE0icDW4Bzwnyv3UTkORFZKSI/isjtwbRHcE56ichMEVkbeO4VWP4McD5wo4hsKCuHFTifD4jIT4Hv9ISI7BL4rK+IFIrIrSLyWyCXdnakaRaRi0VkfuCczxORriGH7iwiBYE0jxOR+oFtwv6GLnX4D+Zi7TbgUKAz0AnoAdwe+Ox6oBDIAloAtwIqIu2AK4HuqtoQOB5YUnrHqvop8AdwVMjis4AXA68fBh5W1UbAvsD4SqRbgRHAnSJSp4zPHwV2A/YBjgTOAy6oaKcisjvwDvAI0BR4EHhHRJqq6lDgBWCkqmaq6rQydnEfcAB2PvcDsoE7Qj7fA2gWWH4+8GTgfJab5kAx2F2BZY2APGBVyH4HA/2AtsAhwNDA8jJ/w4rOg0suHghcrJ0N3K2qK1R1JfA34NzAZ1uBlsDeqrpVVT8MFIkUAfWAg0SkjqouUdXFYfb/EjAEQEQaAv0Dy4L7309EmqnqhkDgiJiqTgBWAheFLg/kQM4AblHV9aq6BPhHyPcqz4nAd6r6vKpuU9WXgAXASRVtKCICXAxcq6qrVXU98P+AM0utOkJV/1TV/2BBZ3AEab4IC0Az1SxS1R9D9vmIqi5V1dXA21gggvC/oUshHghcrLUCQi8oPwaWAdwPLALeE5HvReRmAFVdBFyD3aGuEJGXRaQVZXsROC1Q3HQaMCfkAnYhdve8IFAEM6AK6b8dy9XUD1nWDKhbxvfKjmB/pc9HZbbNAnYFZgeKYtZgRVhZIev8rqp/lNp3qwjSvCcQLtgC/BryeiOQGXhd5m/oUosHAhdrS7EK0KC9AssI3Jler6r7YHfE1wXrAlT1RVU9PLCtYkUiO1HVedgF7QR2LBZCVb9T1SFA88D2r4pIg8okXlWnYhe6y0MW/4bdCZf+Xr9EsMvS56My2/4GbAI6qGrjwGM3Vc0MWadJqe8YPN8VpflnrPisUsr7DV3q8EDgoqmOiNQPedTGimluF5EsEWmGlWf/G0BEBojIfoEij3VYkVCRiLQTkaMCd/mbsYtfUTnHfRH4C9AHeCW4UETOEZEsVS0G1gQWl7efcG4Dbgy+UdUirL7hXhFpKCJ7A9cFv1cFJgEHiMhZYk1SzwAOAiZWtGHge4wG/k9EmgOISLaIHF9q1b+JSF0ROQIYALwSQZqfAm4QkW5i9gusU65wv2EE58ElEQ8ELpomYRft4OMu4B5gFlAAfA3MCSwD2B+YBmwA/gs8rqrvY/UD/4vdxf6K3dHfWs5xXwL6AjNU9beQ5f2AuSKyAas4PlNVNwMEWuUcEcmXUtWPgc9LLb4Kq6j+HvgIC0ZjA/u+VUTeDbOvVdjF+XqsMvZGYECpdJfnJiyH8qmIrMPOX7uQz38FfsdyAS8Aw1V1QUVpVtVXgHsDy9YDbwK7R5CecL+hSyHi9TrOpQcR6Qv8W1VbJzgpLsV4jsA552o4DwTOOVfDedGQc87VcJ4jcM65Gq52ohNQWc2aNdM2bdokOhnOOZdSZs+e/ZuqZpX1WcoFgjZt2jBr1qxEJ8M551KKiJTu0b6dFw0551wN54HAOedqOA8EzjlXw6VcHYFzLn1s3bqVwsJCNm/enOikpI369evTunVr6tQpaxqNsnkgcM4lTGFhIQ0bNqRNmzbYuHWuOlSVVatWUVhYSNu2bSPezouG3M5GjoT8/B2X5efbcueiaPPmzTRt2tSDQJSICE2bNq10DssDgdtZ9+4weHBJMMjPt/fduyc2XS4teRCIrqqcTw8Ebme5uTB6NOTlwe23WxAYP96WO+fSjgcCt7NXXoFLLoENG+Dee+GyyzwIuLS0atUqOnfuTOfOndljjz3Izs7e/n7Lli3lbjtr1iz+8pe/VHiMXr16RSu5MeOVxa7E8uVwxRXw2muw11627MQTYdQoCwQeDFwCjRxppZOhf4b5+TBzJtx4Y/jtytO0aVO+/PJLAO666y4yMzO54YYbtn++bds2atcu+zKZk5NDTk5Ohcf45JNPqpa4OPIcgQNVeOEFOOggmDgRLr4YNm60z7p1s2Kh0DoD5xIgXlVXQ4cO5brrriM3N5ebbrqJzz//nF69etGlSxd69erFwoULAXj//fcZMGAAYEFk2LBh9O3bl3322YdHHnlk+/4yMzO3r9+3b18GDhxI+/btOfvsswmO/jxp0iTat2/P4Ycfzl/+8pft+40XzxHUdEuXwvDh8PbbcOihMHasvR4/Hs4+G375xW7Bxo+3Wy/PFbgYueYaCNych9WqFRx/PLRsCcuWwYEHwt/+Zo+ydO4MDz1U+bR8++23TJs2jYyMDNatW8cHH3xA7dq1mTZtGrfeeiuvvfbaTtssWLCA/Px81q9fT7t27bjssst2asv/xRdfMHfuXFq1akXv3r35+OOPycnJ4dJLL+WDDz6gbdu2DBkypPIJriYPBDWVKjz7LFx7LWzeDP/4B1x9NWRk2H8XQHY2FBbaay8ackmgSRMLAj/9ZKWXTZrE5jiDBg0iIyMDgLVr13L++efz3XffISJs3bq1zG1OPPFE6tWrR7169WjevDnLly+ndesdZw3t0aPH9mWdO3dmyZIlZGZmss8++2xv9z9kyBCefPLJ2HyxMDwQ1EQ//wyXXgrvvguHH265gP3333m97GxYvDj+6XM1UiR37sHioBEjrOrqzjtjc3/SoEGD7a9HjBhBbm4ub7zxBkuWLKFv375lblOvXr3trzMyMti2bVtE6yTD5GBeR1CTqFqz0A4d4D//gUceseeyggBA69ZWNORcEggGgfHj4e6741d1tXbtWrKzswF45plnor7/9u3b8/3337NkyRIAxo0bF/VjVMQDQToqq2fwSy/BAQdYs9CcHPj6a7jqKqhVzp9Adjb8/ntJxbFzCTRz5o7dWUKrrmLpxhtv5JZbbqF3794UFRVFff+77LILjz/+OP369ePwww+nRYsW7LbbblE/TrlUNaUe3bp1U1eBGTNUmzWz56Ii1auvVgXV+vVVR42yZZF47jnb7ttvY5pcV3PNmzcv0UlICuvXr1dV1eLiYr3sssv0wQcfrNb+yjqvwCwNc131OoJ0FLxVGjgQGjaEH3+0ZqCvvQZ77x35fgLZYQoLwxcfOeeqbfTo0Tz77LNs2bKFLl26cOmll8b1+B4I0lVurl30v/gCBgyACROgsmOQBAOB1xM4F1PXXnst1157bcKO73UE6WrSJGuUfcgh8Omn8P77ld+HBwLnagQPBOkoPx/OPNNaCT36aNWbV2Rmwm67lfQlcM6lJS8aSkczZ0KbNrBpExxxhBUJVbVnsDchdS7teY4gHZ1yijUPHTaspF4gN7dqI3OF9i52zqUlDwTp6OmnrX/A+edXf1/Z2Z4jcGmrb9++TJkyZYdlDz30EJdffnnY9WfNmgVA//79WbNmzU7r3HXXXTzwwAPlHvfNN99k3rx529/fcccdTJs2rZKpjx4PBOlm2zYbQ+iEE2yErupq3Rp+/dX261wixWAK1SFDhvDyyy/vsOzll1+OaOC3SZMm0bhx4yodt3QguPvuuznmmGOqtK9o8ECQbiZPtmEZL7wwOvvLzobiYgsGziVSDMahHjhwIBMnTuTPP/8EYMmSJSxdupQXX3yRnJwcOnTowJ133lnmtm3atOG3334D4N5776Vdu3Ycc8wx24epBusf0L17dzp16sTpp5/Oxo0b+eSTT5gwYQJ//etf6dy5M4sXL2bo0KG8+uqrAEyfPp0uXbrQsWNHhg0btj1tbdq04c4776Rr16507NiRBQsWVPl7l+aVxelmzBho3tz6DkRDcPTEX34pee1cLCRgHOqmTZvSo0cPJk+ezMknn8zLL7/MGWecwS233MLuu+9OUVERRx99NAUFBRxyyCFl7mP27Nm8/PLLfPHFF2zbto2uXbvSrVs3AE477TQuvvhiAG6//XbGjBnDVVddRV5eHgMGDGDgwIE77Gvz5s0MHTqU6dOnc8ABB3DeeecxatQorrnmGgCaNWvGnDlzePzxx3nggQd46qmnyj9fEfIcQTpZvtwmljn3XCg1DnqVhfYudi7RQsehbtkyKuNQhxYPBYuFxo8fT9euXenSpQtz587doRintA8//JBTTz2VXXfdlUaNGpGXl7f9s2+++YYjjjiCjh078sILLzB37txy07Jw4ULatm3LAQccAMD555/PBx98sP3z0047DYBu3bptH6QuGjxHkE6ef97K8qNVLATeqczFT4LGoT7llFO47rrrmDNnDps2baJJkyY88MADzJw5kyZNmjB06FA2b95c7j4kTK/9oUOH8uabb9KpUyeeeeYZ3q+gY6dWMCR1cBjrcMNcV5XnCNKFqhULHXZYycQy0dCsGdSt64HAJV6MxqHOzMykb9++DBs2jCFDhrBu3ToaNGjAbrvtxvLly3n33XfL3b5Pnz688cYbbNq0ifXr1/P2229v/2z9+vW0bNmSrVu38sILL2xf3rBhQ9avX7/Tvtq3b8+SJUtYtGgRAM8//zxHHnlktb5fJDwQpItPP4UFC6KbGwDrh+B9CVwyiOE41EOGDOGrr77izDPPpFOnTnTp0oUOHTowbNgwevfuXe62Xbt25YwzzqBz586cfvrpHHHEEds/+/vf/07Pnj059thjad++/fblZ555Jvfffz9dunRhccjkT/Xr1+fpp59m0KBBdOzYkVq1ajF8+PBqf7+KSEVZkWSTk5OjwXa8LsRFF8HLL1sFWsOG0d13nz7WL6Eq4xU5V4758+dzYDRzsA4o+7yKyGxVzSlrfc8RpIMNG2DcOMsmRzsIgOcInEtzHgjSwSuvWDCIdrFQULB3cYrlHp1zkfFAkA7GjIF27aBXr9jsv3Vr2LzZpq10LspSrXg62VXlfHogSHULFsDHH+84wFy0eV8CFyP169dn1apVHgyiRFVZtWoV9evXr9R23o8g1T39NGRkwHnnxe4Yob2Lw/SudK4qWrduTWFhIStXrkx0UtJG/fr1aV3JUQA8EKSyrVttgLkTT4Q99ojdcTxH4GKkTp06tG3bNtHJqPFiVjQkInuKSL6IzBeRuSJydRnriIg8IiKLRKRARLrGKj1padIkG1YiVpXEQS1bWrGTdypzLi3FMkewDbheVeeISENgtohMVdXQQTtOAPYPPHoCowLPLhJjx1pOoH//2B6nTh1o0cIDgXNpKmY5AlVdpqpzAq/XA/OB7FKrnQw8p+ZToLGItIxVmtLKsmXwzjtWN1A7DiV83pfAubQVl1ZDItIG6AJ8VuqjbODnkPeF7BwsEJFLRGSWiMzySqWA556DoiJrLRQPPnexc2kr5oFARDKB14BrVHVd6Y/L2GSndmSq+qSq5qhqTlZWViySmVpUrVjo8MOt/0A8eI7AubQV00AgInWwIPCCqr5exiqFwJ4h71sDS2OZprTw8cfw7bfxyw2ABYLff4dNm+J3TOdcXMSy1ZAAY4D5qvpgmNUmAOcFWg8dCqxV1WWxSlPaGDMGMjNh0KD4HTO0L4FzLq3EspaxN3Au8LWIfBlYdiuwF4CqPgFMAvoDi4CNwAUxTE96WL/eht496ywLBvES2pdgv/3id1znXMzFLBCo6keUXQcQuo4CV8QqDWlp3DjYuDG+xULgOQLn0piPNZRqxoyxGcgOPTS+x/Xexc6lLQ8EqWTePJuJ7MILYzfAXDiZmdCokecInEtDHghSydix1nns3HMTc3zvS+BcWvJAkCq2brVOZCedBM2bJyYN3pfAubTkgSBVTJwIK1fGfoC58gRnKnPOpRUPBKlizBgbBfT44xOXhtat4ddfYdu2xKXBORd1HghSwdKl8O67MHRofAaYCyc728Y3Wr48cWlwzkWdB4JU8OyzUFwc/74DpXlfAufSkgeCZDVyJOTnlwww16cP/PyzLU8U70vgXFryQJCsuneHwYPh4Ydh0SLo1cved++euDQFA4HnCJxLKz5ncbLKzbUxhfr3h7p14amn7H1ubuLS1KyZpcUDgXNpxXMEySw313rzbtkCl12W2CAAUKsWtGrlRUPOpRkPBMnsvfdgxQro3RtGjbI6g0Tz3sXOpR0PBMkqPx/OPNNeX3mlFQsNHpz4YOC9i51LOx4IktXMmTB8uL0+5JCSOoOZMxObrmDvYt1pRlHnXIryQJCsbrzRevDWrQsHHGDLcnNteSK1bm3TVa5Zk9h0OOeixgNBMisogA4dEtubuDTvS+Bc2vFAkMwKCqxYKJl472Ln0o4HgmS1ciUsW5Z8gcBzBM6lHQ8Eyerrr+052QJBy5b27DkC59KGB4JkVVBgz8kWCOrWhRYtPBA4l0Y8ECSrggK74CZqNrLyeF8C59KKB4Jk9fXXyZcbCPLexc6lFQ8EyaioCL75JnkDgecInEsrHgiS0aJFsHlzcgeC1autY5lzLuV5IEhGyVpRHBTsS7B0aWLT4ZyLCg8EyaigADIy4MADE52SsnlfAufSigeCZFRQAO3bQ716iU5J2bx3sXNpxQNBMkrGoSVCeY7AubTigSDZrF0LS5YkdyBo2NAeniNwLi14IEg233xjz8kcCMD7EjiXRjwQJJtgi6GOHRObjop4XwLn0oYHgmRTUACNG5dUyCYrzxE4lzY8ECSbYEWxSKJTUr7sbBsmu6go0SlxzlVTzAKBiIwVkRUi8k2Yz/uKyFoR+TLwuCNWaUkZxcXJPcZQqOxsCwLLlyc6Jc65aopljuAZoF8F63yoqp0Dj7tjmJbU8OOPsH59agQC70vgXNqIWSBQ1Q+A1bHaf1pK9qElQnlfAufSRqLrCA4Tka9E5F0R6RBuJRG5RERmicislStXxjN98VVQYHUDHcKeiuThOQLn0kYiA8EcYG9V7QQ8CrwZbkVVfVJVc1Q1JysrK17pi7+CAth3X8jMTHRKKtasGdSp4zkC59JAwgKBqq5T1Q2B15OAOiLSLFHpSQrJPrREqFq1oFUrzxE4lwYSFghEZA8RayMpIj0CaVmVqPQk3MaN8N13qRMIwPsSOJcmasdqxyLyEtAXaCYihcCdQB0AVX0CGAhcJiLbgE3AmaqqsUpP0ps7F1RTKxBkZ8MXXyQ6Fc65aopZIFDVIRV8/k/gn7E6fspJpRZDQdnZMHGiBbBk7wDnnAsr0a2GYm/kSMjP33FZfr4tTyYFBdCgAbRtm+iURK51ayvSWrMm0SlxzlVD+geC7t1h8GC7+G/ebM+DB9vyZFJQYAPN1UqhnyTYl8DrCZxLaSl01ami3FwYPx5OPtnG0B840N7n5iY6ZSVUU6vFUJD3JXAuLaR/IAC76J9zDmzbBj17JlcQAJsEfvXq1AsE3rvYubRQMwJBfj688grsvjtMm7ZznUGipWJFMVg/AvAcgXMpLv0DQbBOYPx4uOACG+Fz0KDkCgapMhlNaXXrQvPmniNwLsWlfyCYObOkTiAvz4ZOvvJKW54sCgpgr71sQppUk53tOQLnUlzM+hEkjRtvLHndq5cVD33/PTz3XOLSVFoqVhQHtW4NP/2U6FQ456oh/XMEoWrXhhNPhHfesYrjZLBlCyxYkLqBwOcudi7l1axAAFY8tHo1fPJJolNiFiywoJTKgWDVKuuj4ZxLSTUvEBx/vFVyTpiQ6JSYVG0xFOR9CZxLeREFAhG5WkQaiRkjInNE5LhYJy4mGja0iuO33rKOXIlWUAD16sH++yc6JVXjvYudS3mR5giGqeo64DggC7gA+N+YpSrW8vJg0SJYuDDRKbFAcNBBVn+RijxH4FzKizQQBIeW7A88rapfhSxLPSedZM/JUDyUyi2GwHsXO5cGIg0Es0XkPSwQTBGRhkBx7JIVY3vuCV26JD4QrFwJy5aldiBo1Mim1vQcgXMpK9JAcCFwM9BdVTdiE8xcELNUxUNenrUcWrkycWn4+mt7TuVAAFY85DkC51JWpIHgMGChqq4RkXOA24G1sUtWHOTlWWXxO+8kLg2p3mIoyHsXO5fSIg0Eo4CNItIJuBH4EUiirrlV0KWLXcDeeitxaSgogBYtbLyeVOZzFzuX0iINBNsC8wmfDDysqg8DDWOXrDgQsVzBe+/Bpk2JSUOqVxQHZWfbUNpFRYlOiXOuCiINBOtF5BbgXOAdEckgMBF9SsvLs6kWZ8yI/7G3bbMJ69MlEBQVwYoViU6Jc64KIg0EZwB/Yv0JfgWygftjlqp4yc21Fi+JaD20aJENy5AOgSDYl8ArjJ1LSREFgsDF/wVgNxEZAGxW1dSuIwDr0duvH7z9ts1TEE/pUlEM3rvYuRQX6RATg4HPgUHAYOAzERkYy4TFTV6eteWfPTu+xy0ogIwMOPDA+B43Frx3sXMpLdJxDW7D+hCsABCRLGAa8GqsEhY3/ftDrVpWPNS9e/yOW1AA7dtbriTVZWVBnTpeNORcioq0jqBWMAgErKrEtsmtaVM4/PD41xOkS4shsEDasqXnCJxLUZFezCeLyBQRGSoiQ4F3gEmxS1ac5eXZhXnJkvgcb+1a+PHH9AkE4L2LnUthkVYW/xV4EjgE6AQ8qao3xTJhcZWXZ89vvx2f46XL0BKhvHexcykr4uIdVX1NVa9T1WtV9Y1YJiru9t/fyuvjVTyUTi2GgoK9i5NhjgfnXKWUGwhEZL2IrCvjsV5E1sUrkXGRlwfvv2/FNrFWUABNmpQ0u0wH2dnwxx/xOX/OuagqNxCoakNVbVTGo6GqNopXIuMiL896+06eHPtjBSuKJXWndNiJ9yVwLmWlR8ufaDj0UGjWLPbFQ8XFVkeQTsVC4L2LnUthHgiCMjJgwACYNAm2bo3dcZYsgQ0b0i8QeI7AuZTlgSBUXh6sWQMffRS7Y6RjRTFAq1b27IHAuZTjgSDUscdaT99YFg8VFFjdQIcOsTtGItSrZz2MvWjIuZQTs0AgImNFZIWIfBPmcxGRR0RkkYgUiEjXWKUlYpmZcPTRNllNrJpBFhTAfvtBgwax2X8ieV8C51JSLHMEzwD9yvn8BGD/wOMSbBa0xMvLgx9+sLkCYqGgADp2jM2+E817FzuXkmIWCFT1A2B1OaucDDyn5lOgsYi0jFV6IjZggD3Honjojz9sHoJ0qx8I8hyBcykpkXUE2cDPIe8LA8t2IiKXiMgsEZm1cuXKGKcqG3JyYhMI5s61Iqd0DgS//WYT7jjnUkYiA0FZvanKLJhX1SdVNUdVc7KysmKcLODkk+Gzz+DXX6O733QcYyhUsC/B0qWJTYdzrlISGQgKgT1D3rcGkuMKEhyEbuLE6O63oMAqidu2je5+k4X3JXAuJSUyEEwAzgu0HjoUWKuqyxKYnhIdO8Lee0e/eChYUVwrTVvteu9i51JSLJuPvgT8F2gnIoUicqGIDBeR4YFVJgHfA4uA0cDlsUpLpYlYrmDqVNi4MTr7VE2vyWjK4jkC51JSpFNVVpqqDqngcwWuiNXxqy0vDx59FKZNKykqqo6lS2H16vQOBI0aWdGXBwLnUkqallFEQZ8+dmGLVvFQug4tEUrE+xI4l4I8EIRTty6ccILNWlZcXP39BQNBunYmC0pUX4KRIyE/f8dl+fm23DlXLg8E5cnLgxUr4PPPq7+vggLYay9o3Lj6+0pmwZnK4q17dxg8uCQY5Ofb++7d458W51KMB4LynHCCDU8djeKhdK8oDsrOtvqQaOSiKiM3F8aPh1NPtQA+eLC9z82NbzqcS0EeCMrTpInVFVQ3EPz5JyxYUHMCwbZtlpOKp+Ji+O9/barMt9+2kWQ9CDgXEQ8EFZjeIM+Ghli8ePuyShc9L1hgF8eaEAgS0Zdg3To4/XS47TYbDrtZMxg3Dt55J35pcC6FeSCowK5nnATAgvvfBqpY9FwTWgwFPDd9574EMa2znT8fevSwXFuDBjbD3IQJlkMYOHDnCmTn3E48EFTgsKWvsSGrDUv/NYGTTrIg8N4t+eTOjODKFmzJUlBgd6r775/2LVn2PdJyBAvzLRDEtM72jTcsCPz+O1x8sRUJHXUUHHYYXH21DX43fnwMDuxceolZh7K00b07DTbcxZH8xLkTf2FI2zl0vvcCeGq0DUpXVLTzY9s2e27cGE47zcrNO3SADz8sqcRMU71PbU5xRm0mPlHI2HowdmwM6myLimDECPif/4GePeHVV0uKpILuvdcmGJo+HTZtgl12iWICnEszqppSj27dumm8LfjLP1VtkIiqP7p0UW3WTHXGjLinP9Y2blSdOlX1lltUe/ZU/ZE99RnOU1C9+eYoH+y331SPPdbO6SWXqG7eHH7dqVNtvZtuinIinEs9wCwNc131HEEF8vNh8AuXM++wKWT9922+3+9YHll0Ihl1Mxh6UQYdO2VYE9PQR+3aO75/6SV7jBgRl5YsI0daUUzoofLzYeZMuPHG6m+/dau9njHDbrg/+QS2bLGv3aMH/JnVmr1XFUIxPPigzf55zDFR+GJffGE5rKVLYfRouOii8tc/5hi48EJ44AEYNAi6dYtCIpxLQ+EiRLI+4p0juO8+1Tn/mGF38yNGqDZrplNvnaGtWtnN5ogRqtu2lbODGTtuG48cQfCQwUOVfl/Z7adNU23cWHX4cNX+/VUzM+27i1hG5/rrVSdNUl23zrZ5q+5A3bBnO330UVuvfn3V6dOr+aWee8521Lq16mefRb7d77+rtmyp2qmT6pYt1UyEc6mLcnIEorGapD1GcnJydNasWfE7YLC2M1jQHXj/5/PjufyVXMaOtSbrL75orRYj2TaSQvNI7+pVbSy7wsIdH8E79qZNbdKwgw6CPfawOuvQR/36Oy+rVw9+/BHGjLHO0AsW2HEA2rWzO/yjjoK+fW3/pdM95PNr2XPyaFi/nptvEe67D44/HiZPrsL537oVrr/eBgA88kg7d82bV24fb70Fp5wC99xjTUydq4FEZLaq5pT5YbgIkayPuNcR3HffzrfSM2bYclV96inVevVU99yzjBvVCrYtT/CufNIk1ZkzVe++2+7EzzxT9ZxzVPv2Vd1vP7tJLl0dUauW3ThnZ9v7ffZRPfJIK7/v3Fn1wANtWXa2HaNhQ9W6dcNXb3TqZDfkhYURnrP777cN16zR4mLVc8+1t08/XcF2pc/XsmWqBx9sG193nerWrREmoAyDB9uXnDu36vtwLoVRTo4g4Rf2yj4SUVlckVmzVNu0Ua1TR/Xxx1WLi6u3vw0bVMePt4t36YtynTp2rMMPt6Bwww2qDz2k+uqrqp9+ahfrrVurViJVVKS6aZPqmjWqr72muvvuqrffXskSrfvuU73tNkts4KK7ZcoMfXL/+zQjwwJbWKFlUp98YgkA2191LV9u+zvssArK8pxLTx4I4mDVKis/B7sD/uOPym3/xx+qr7yiOmiQ6q672n6aN1ft1s1eX3SR6q+/2sW6ItGuI6jU9jNmqO62myV6ypTtG/8xcYZ26WLf7fPPA+tu2qT600+qs2erTp6s+vzzqpddprrLLpatqVVLdfToyBIdieeft3Q99FD09lld1cg1OlcZHgjipKjIinBEVDt2VP322/LXD178Bw/e8eJ/2WV2LZg6tWr1zNW9tlT72vTvf9uX6dxZtUED1TPOUB06VDcdc6J+UbeHLqnVVosaZO6c3Qk+ROz5hhsiPGCEiostWu+6q+r330d331VV3ajtXIQ8EMTZlCmqTZta3cHdd+/42aRJVsZ/xhklF/+sLGuRM2NGSalFSl8fNm+2Mqzghb1ePau06NJFN/Q+TsfXPVvH7naNrr/lXtUnn1R94w3Vjz5SXbBA9c03Y9vK6qefrFLkmGOqX4YXLS++aBVAQ4em0I/sUo0HggRYskS1XTs7w2ecYWXuubkl18asLNVLL7VmlWXVgaZ0icGMGVYef+WVFhFLtR3973+t9CcnR3X9+lLbxSP6jRplP8KYMdHdb2WsWKH62GOqvXvvmBvq0kV19erEpculLQ8ECbJ5s2penu5Q4jFggLXLr04DmKQW4cX8rbesCuCEE0Ka98cr+hUVqfbpY3UZv/wS3X2XZ906a37Vr59qRob9URx8sOqFF6o2aWIV2WCvx49PnhyLSwseCBIs2HwyGo1fkl4lLub/+pedlwsuSMA179tvre3tySfH9uCbN1vR16BBJW19997bxuMoKNg5UP7rX6q1a9t6AwZYUZZzUeCBIIES0LE4pdxxh27voR13wf4O48ZVbz+lg9+2baoPPGBlX8EWVFlZVlT28cc7Bp6yAufUqaonnmiVSJmZqg8/7E1eXbV5IEiQlK7wjZPiYisZAdUnnojzwbdutYt1VpYNZldVwR/2scdUr7nGinbAKkLOO8+axlalLPCHH6wYCVR79FD96quqp9HVeB4IEiSlK3zjaOtWa9Upovr3v+/4WczPV0GBFcWcc07ltisuVl240HoQnn56yQBMtWpZD+Y777RhWauruNhaFWVlWTpvvjk6+3U1jgcCl/Q2bChpZfXII7YsbjmoYPnUO++Uv97SpdZHYuhQG1Mk2Apgr72souOUUzRm5VyrVtkxQHXffa3FgXOVUF4g8BnKXFJo0MDm7WnVyiYXu+CCiMfnq7569aBNG7j0Upv/GGyEv7vvtmkvr77aJhZq1QrOOceW9ewJo0bBd9/BkiVw7rnw0Uc21PioUdGfInP33W2Wn+nTQcSG2M7JgTff3HG9NJ8Bz8VIuAiRrA/PEaS3RYtKOtrVqWOD6910k+rrr1di0LvKmjHDxtkWsU4fZ59txTC1aun2sv7jjlMdOdKGwyg9zke8K4M2blS99VZLn4i9Li72SihXLnwYapcq8vNtzvkjjoApU2wY7B9+sNGowWb97NnTJsDp2dNuijMzqz8ZD/n5cOKJNq0l2Ljdp51md96HHmq5hnCqffAqKiiAM86wccKbNoX16+HUUy3N++1nc2S3bAm1ysj4JyrNLmF8GGqXEsLdWE+ebL2RH3pIdcgQKyIPHXL74IOtY1pmpo1RFzr6aqVujm+91XZ6440x+X4xsW1byWiHTZvuPJ74LrvYCTr1VNW//tWG9JgxQ/Xll71JWw2D5whcKqjMTepvv9nyzz6zx+ef2wQ9UDJP/WOPWV1DRIKTBl12mZXxx6VyIgpKp/ullyw3sGiRPb77ruR58WKbUzSoTh0oLoYDDoCff7btzzkncd/FxZTnCFzaKy5W/e67koY7weL9Xr1Ux461VklhpWqHj8qme9s21R9/tBZHTzxho7secMCOOYi2bVUvucQmuEi3MY9qeHtuvNWQS3cidlMbbLjTpAkMHw6rVsGwYVZUPnw4zJpVMu3mdjNn7pgDyM219zNnxv17VEpl052RYZUuRx9tLaT697ds1O232wm76iro2NFyFQMH2tyrPXva5//5T0luYuTInVtFpUJrpe7dLfcUTHswN9W9e2LTlQzCRYhkfXiOwJUl3M3x9OmqH36oev75VlwenCbhn/+0ee1rrPJyE1u22Em74w4bCC84QF6DBjb0xRVXWO/p4KiyqZKD2rLF5ktt2NDqTHbfPfnTHEV4HYFLd5HUL6xZYze7o0fDF19A/fowaBDsuqvdGB51VPhtq3vspFOZRK9da59NnQrvvWd1DmCtkQ4+2Ooe7rkHzj/fchaJTndxsTU1mzsXvvmm5LFw4Y51JGD1I0cdZfvr2xeaN49t+hMoYXUEQD9gIbAIuLmMz/sCa4EvA487Ktqn5whcNMyebTPBNWpkN7sZGVY0/tNPqhMmWAOcN96wqY6XLbNOxYWF9vmSJTYM0OLFVi/x7LN2g/zss1YMnyo3yFX2ww/W+ujAA3esXwDrcT1ggLXAGjdOdf78nQfMq05ZfejJLS62YzRqZJN7DB1qY0cFO6IEH3vvbTmZm26yIToaN7a5Xxs0UO3Z03IIwXUPPlj1qqus48qqVdFJc5IgETkCEckAvgWOBQqBmcAQVZ0Xsk5f4AZVHRDpfj1H4KLpjz/g1VfhgQfsprG66te3K8q118I110CLFtXfZ1IKlq8PHw6PP15yN15QAF99ZX0biops2S67WM7hkEOgUydbfs898Mordice3Ne//mXr/f57yWPNmp1ff/89fP211Xn8+WdJmvbYw7YPPjp0sP4gjRrtmOZgvUrw/Usv2TozZtiyjz6CjRut4qlzZ1u3aVN48MGd0xxp67IkyDaWlyOIZSA4DLhLVY8PvL8FQFX/J2SdvnggcEni8sutBeVxx1nfslq1Sh4i5b+vVQtefBHeftuGy/jjD9tnt25wwgn26NEDatdO7HeMinAX1NCL4p9/wrx5JYEh+PzbbyX7qVXLTtb69RUfs359K3Zq3NieV6ywIqoTToCbbrKLfrNm5e8j0ovxli3WHjk/3x6ffGLfJ/hDd+tmdw1XXAF9+thxs7LsuWFD++OoyjmrbrorkJCiIWAg8FTI+3OBf5Zapy+wCvgKeBfoEGZflwCzgFl77bVXDDJNrqar7rwRpbd/4gnVe+6xmSiDTVmbNFEdPNjqK5cts+1SssShqokuLrYytnffVf3f/1Xt2NFOTM+eNrn3o4/aoH4TJ9q8DfPm2fqbNu18rHhO8rFpkx1jxAibe7t0cVjoo25d1VatVDt1Uj36aNUzz7R5KP72N9Wrr7ZiqCFDbJ6Kxx9XnTvXitpWrLA2zqWHLwn9vtVs3kwiRh8FBpURCB4ttU4jIDPwuj/wXUX79ToCF23V/T+raPvVq60oe+hQ1T32KLlmdOmietZZdk2YOrVqx05ZVb2YJ7LPR/BYt99ulUj//rfqp59a4Hr6aZvo6MYbbZTYk05SPfRQ1f32K5mcKNLHLrvY/vfaS7V9e9WuXS1o1qljc99W8fuWFwhimVEtBPYMed8aWBq6gqquC3k9SUQeF5FmqvobzsVJec3xIyn+rWj7Jk2sFGDwYGvQ8tVX8O679hg3zorMjzvOBkBdtsya+AP8+qvVMZRV0gBJUexcNaWLRXJzIy8mqe6PFa00H3VUyfsTT6x4+y1bbNTaSy6BU06B11+Hv/7VeoFv3GhliaHPZS3LyrJ9jBgR/e8aLkJU9wHUBr4H2gJ1seKfDqXW2YOSeooewE/B9+EeniNw6eT3322e+s6ddfuIq6E3h40b243lBRdYycuECdZSqazWSSmTm0jF8rDqpjla2c5qFIeRqIlpsOKeb4HFwG2BZcOB4YHXVwJzA0HiU6BXRfv0QODSTen/8XHjVN97z6YqvuwyG4o7tEgpWBR98MGqffpYa8lTTrGg8eqrO06JHE4qXotTWrSazJb1PkLlBQLvUOZcAlWmMcnvv1urzAULYP78kudg/66gXXeFffbZ8bHvvvbcpo01wKlOIxYXZ3FoNeSBwLkEqu7/ePACPmgQvPCCde6tXdua2i9ebM8bN+64TXa2BYVddrEm88cdB++/D2PG2HQG4eokopVmlxgeCJxLQ5Hc1atak/vvvy/7UVi44z4bNrTcQ+nHfvtB69bWh8tzE6nJA4FzaSjauYlzz7X+UosX2+OHH3aevqBtWwsM9erZ0EMnnWTPwQ63Lnl5IHDO7SCSu/qiIssxBAND8LFokT0HOwSLWAfbfv3g+ONtFImyZsd0ieWBwDm3g+rmJmbMsMDRv7+N1ZSdXVJp3aKFBYR+/eDYYyse+cHFhwcC51zUhMtNPPGE9X2aPNlGq161ynIL3buX5BZ69LCx27yyOf7KCwSegXPOVUq4zr2LF8N559nge8uX21zSd91lFcz33AO9e1vn2EmTIC/PtgGfKCwZeI7AORdzq1fD9OmWW5g8GZYGBptp1crmvRk9GoYMSWwa053nCJxzCbX77tY6acwYq4AuKLDhepYuteKks86Cww6D//s/m3vaxZcHAudcXInYtAQFBTZ+WpMmcNFFNuT/ddfBXntZMdIjj5TkHFxseSBwzsVVaGXz3XfDa6/Bm2/CP/5h0wrfcw9s2ABXX22d2Pr0gX/+00ZjHTnSti+9v5EjE/JV0oYHAudcXJU3kvQBB8Btt9lQ3fPnw9/+ZmMsXXWV1Se8+KJVNL/2mm3rFc3R4ZXFzrmkN3eu9V4eN84G2wPYc09rovrgg3Dxxd6JrSLej8A5lxZULShcfjl8+GHJ8qwsGzyvXz97bt48cWlMVt5qyDmXFkRg5UorNhoxwloj3XKLXfynTLHxklq0sPnlb7vNgsXWrbat1y+E54HAOZcySlc0v/qq9UG48ELrxDZrllU277or3HefVTQ3awannWafDxxYEgy8fqGEFw0551JGZcZIWru2pBPblCnw00+2PCPD9rFwoVU615RRU72OwDlXo6laJfOUKfDoozYXA8Ahh9iwGGedBS1bJjaNseZ1BM65Gk0EDjzQhshetw6uvx4yM22+hRtusP4K/fpZ89TSM7rVBB4InHM1Qmj9wgMPwIQJ1sP5mWeswnn+fDj7bKtsvuACW7+4ONGpjg8PBM65GiFcR7bly62C+YcfbO7mwYOt7uCoo6BNG7j1Vss1pHOLI68jcM65UjZuhLfegueft3qF4mKoXRuGD4c77oBvvkm9eZq9jsA55yph111tWOxJk+CXX2wcpL33tjGPmjcv6byWkbHjvM6pygOBc86VY489bFTURYvgkktsWYsWVrF85JHWqW3AAHj4YZg3z1oopRoPBM45F4H8fHj9devR/OefNmLq669b89OFC+Gaa6BDBxsD6YILLFCsWGHbJnuvZg8EzjlXgdI9msePh2HDoHFjePxx+O47q2x+8kmbYOett0paIHXuDLNnw6mnWue20P0lS69mryx2zrkKVKZHM0BREcyZA1On2uPjj0vGPMrOtlFTr77achPt2lldQ6x5z2LnnEugP/6ADz6w3MSnn0KdOiWBITMTunaFnBwLNjk5sO++1gkOKh+EwikvENSu6hdzzjkXmQYNoH59q3AeMQJGjbILfEaGXdBnzYLHHrO6B7Aip2BgqFfPBst75RXr2xBaTBUtHgiccy7GQi/eubn2CL4/7zxbZ+tWm2shGBhmzoT774dt2+zzY46Bo4+GL7+Mfv8FDwTOORdj5U3PGVxWp45VLHfubDOuAWzeDAUFtt7o0TBtmuUoot2JzQOBc87FWFll+cGcQXnq14cePayO4ZdfSoqVItm2Mrz5qHPOJbGymq4OHrxzv4Tq8EDgnHNJrLxipWiJafNREekHPAxkAE+p6v+W+lwCn/cHNgJDVXVOefv05qPOOVd5CRl0TkQygMeAE4CDgCEiclCp1U4A9g88LgFGxSo9zjnnyhbLoqEewCJV/V5VtwAvAyeXWudk4Dk1nwKNRSTNJ4xzzrnkEstAkA38HPK+MLCssus455yLoVgGAiljWekKiUjWQUQuEZFZIjJr5cqVUUmcc845E8tAUAjsGfK+NbC0Cuugqk+qao6q5mRlZUU9oc45V5PFrNWQiNQGvgWOBn4BZgJnqerckHVOBK7EWg31BB5R1R4V7Hcl8GMVk9UM+K2K28ZSsqYLkjdtnq7K8XRVTjqma29VLfNOOmY9i1V1m4hcCUzBmo+OVdW5IjI88PkTwCQsCCzCmo9eEMF+q5wlEJFZ4ZpPJVKypguSN22ersrxdFVOTUtXTIeYUNVJ2MU+dNkTIa8VuCKWaXDOOVc+71nsnHM1XE0LBE8mOgFhJGu6IHnT5umqHE9X5dSodKXcDGXOOeeiq6blCJxzzpXigcA552q4tAwEItJPRBaKyCIRubmMz0VEHgl8XiAiXeOQpj1FJF9E5ovIXBG5uox1+orIWhH5MvC4I9bpChx3iYh8HTjmTkO7Juh8tQs5D1+KyDoRuabUOnE7XyIyVkRWiMg3Ict2F5GpIvJd4LlJmG3L/XuMQbruF5EFgd/qDRFpHGbbcn/3GKTrLhH5JeT36h9m23ifr3EhaVoiIl+G2TYm5yvctSGuf1+qmlYPrM/CYmAfoC7wFXBQqXX6A+9iQ1wcCnwWh3S1BLoGXjfEOtuVTldfYGICztkSoFk5n8f9fJXxm/6KdYhJyPkC+gBdgW9Clo0Ebg68vhm4ryp/jzFI13FA7cDr+8pKVyS/ewzSdRdwQwS/dVzPV6nP/wHcEc/zFe7aEM+/r3TMESTlqKequkwDcy2o6npgPqkzwF6iR4k9GlisqlXtUV5tqvoBsLrU4pOBZwOvnwVOKWPTSP4eo5ouVX1PVQNTnvMpNnRLXIU5X5GI+/kKEhEBBgMvRet4EaYp3LUhbn9f6RgIkn7UUxFpA3QBPivj48NE5CsReVdEOsQpSQq8JyKzReSSMj5P9CixZxL+nzMR5yuohaouA/tnBpqXsU6iz90wLDdXlop+91i4MlBkNTZMUUciz9cRwHJV/S7M5zE/X6WuDXH7+0rHQBC1UU9jQUQygdeAa1R1XamP52DFH52AR4E345EmoLeqdsUmCrpCRPqU+jyR56sukAe8UsbHiTpflZHIc3cbsA14IcwqFf3u0TYK2BfoDCzDimFKS9j5AoZQfm4gpuergmtD2M3KWFbp85WOgSBqo55Gm4jUwX7oF1T19dKfq+o6Vd0QeD0JqCMizWKdLlVdGnheAbyBZTdDJeR8BZwAzFHV5aU/SNT5CrE8WEQWeF5RxjqJ+ls7HxgAnK2BwuTSIvjdo0pVl6tqkaoWA6PDHC9R56s2cBowLtw6sTxfYa4Ncfv7SsdAMBPYX0TaBu4mzwQmlFpnAnBeoDXMocDaYBYsVgLlj2OA+ar6YJh19gish4j0wH6fVTFOVwMRaRh8jVU0flNqtbifrxBh79IScb5KmQCcH3h9PvBWGetE8vcYVWJzhd8E5KnqxjDrRPK7RztdofVKp4Y5XtzPV8AxwAJVLSzrw1ier3KuDfH7+4p2DXgyPLBWLt9item3BZYNB4YHXgs2n/Ji4GsgJw5pOhzLshUAXwYe/Uul60pgLlbz/ynQKw7p2idwvK8Cx06K8xU47q7YhX23kGUJOV9YMFoGbMXuwi4EmgLTge8Cz7sH1m0FTCrv7zHG6VqElRsH/86eKJ2ucL97jNP1fODvpwC7WLVMhvMVWP5M8O8qZN24nK9yrg1x+/vyISacc66GS8eiIeecc5XggcA552o4DwTOOVfDeSBwzrkazgOBc87VcB4InIsjsRFTJyY6Hc6F8kDgnHM1nAcC58ogIueIyOeBsef/JSIZIrJBRP4hInNEZLqIZAXW7Swin0rJ+P9NAsv3E5FpgUHx5ojIvoHdZ4rIq2JzBrwQ7B3tXKJ4IHCuFBE5EDgDG2SsM1AEnA00wMY96gr8B7gzsMlzwE2qegjWcza4/AXgMbVB8XphPVrBRpe8Bhtzfh+gd4y/knPlqp3oBDiXhI4GugEzAzfru2ADfhVTMijZv4HXRWQ3oLGq/iew/FnglcC4NNmq+gaAqm4GCOzvcw2MaSM2G1Yb4KOYfyvnwvBA4NzOBHhWVW/ZYaHIiFLrlTc+S3nFPX+GvC7C/w9dgnnRkHM7mw4MFJHmsH3u2L2x/5eBgXXOAj5S1bXA7yJyRGD5ucB/1MaTLxSRUwL7qCciu8bzSzgXKb8Tca4UVZ0nIrdjs1HVwkaqvAL4A+ggIrOBtVg9AtgQwU8ELvTfAxcElp8L/EtE7g7sY1Acv4ZzEfPRR52LkIhsUNXMRKfDuWjzoiHnnKvhPEfgnHM1nOcInHOuhvNA4JxzNZwHAuecq+E8EDjnXA3ngcA552q4/w9CMpHLJicZSwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "test(base, test_loader, criterion, use_cuda)"
+    "plot_losses(history)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "played-demographic",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA6MklEQVR4nO3deXxcdbn48c+TvdnbJE2TNt3SUhqgtKWUNiC7yqaIiEABUVSsUlG5Lnjd8Kr3h8v1yrVIRVTWsqiAqFVWadGU0pZudE9ClzR72kyWZrLN9/fHOROmaZZJMmfW5/16zaszc7ZnzqTnmfNdxRiDUkqp2BUX6gCUUkqFliYCpZSKcZoIlFIqxmkiUEqpGKeJQCmlYpwmAqWUinGaCJSKEiLyQxFpFJHaUMcCICL3iMjjoY5DDU8TgRqQiLwuIsdEJDnUsUQKEZkuIkZE/tbv/cdF5B6Hj10E/AdQYoyZ5OSxVPTRRKBOIiLTgfcBBvhwkI+dEMzjOWSJiJwb5GNOA5qMMfVBPq6KApoI1EA+AbwJPAzc6rtARIpE5FkRaRCRJhFZ6bPssyKyW0RaRWSXiCy03zciMstnvYdF5If28wtFpEpEvmEXafxeRMaLyF/tYxyzn0/x2X6CiPxeRKrt5c/b778jIh/yWS/RLiqZ3/8D2nFe5fM6wV53oYik2L/im0SkWUQ2ikj+CM7fT4AfDrbQPk/lInJURF4QkUJ/dioiWSLyqH1eDorIt0UkTkQuBV4GCkWkTUQeHmT7q0Rkq/2ZykRkns+yAyLyTft7O2af3xR/YhaR00TkZXtZnYj8p89hk+yYW0Vkp4gs8tnuGyJyxF62V0Qu8ec8KAcYY/ShjxMeQDnwBeAsoBvIt9+PB7YB/wukASnAefay64AjwNmAALOAafYyA8zy2f/DwA/t5xcCPcCPgWRgHJADXAukAhnAH4Dnfbb/G/A0MB5IBC6w3/868LTPelcDOwb5jN8FnvB5fSWwx37+OeAv9vHj7fOQ6cd5m25/1nT7XFxqv/84cI/9/GKgEVhof95fAuv8/F4eBf5sn5PpwD7g0z7nsWqIbRcC9cA59me6FTgAJNvLDwDvAEXABODfPt/RoDHbsdRgFUul2K/PsZfdA7iBK+xj/j/gTXvZHOAwUOhz7opD/bcfq4+QB6CP8HoA52Fd/HPt13uAr9jPlwINQMIA270IfGmQfQ6XCLqAlCFimg8cs58XAB5g/ADrFQKt3os28Efg64Psc5a9bqr9+gngu/bz24AyYN4Iz503ESRgJVLvRc83EfwW+InPNun2+Z4+zL7jgU6sOgDve58DXvc5j0MlggeAH/R7by/vJdEDwHKfZVcAFcPFDNwIbBnkmPcAr/i8LgE6fM5/PXApkBjqv/tYf2jRkOrvVuAlY0yj/Xo17xUPFQEHjTE9A2xXBFSM8pgNxhi394WIpIrIr+3ijxZgHZAtIvH2cY4aY47134kxphrrl+y1IpINXI51gT+JMaYc2A18SERSsepCVtuLH8NKbE/ZxU8/EZHEEX6m3wD5vkVVtkLgoE8cbUATMHmY/eUCSb7b2s+H285rGvAfdrFQs4g0Y51L32Kpw/327V02VMzDfe++LZiOAykikmCf/y9jJYt6EXnK3yIyFXiaCFQfERkHfBy4QERq7TL7rwBnisiZWBeKqYNU6B4GigfZ9XGsYhav/q1a+g+B+x9YRQfnGGMygfO9IdrHmWBf6AfyCHAzVlHVemPMkUHWA3gS6xft1cAu++KEMabbGPN9Y0wJUApchVVv4jdjTDfwfeAHdtxe1VgXZesDiaRhFYUNFSdYRTPdvtsCU/3Yzusw8CNjTLbPI9UY86TPOkX99l3tR8xDfe9DMsasNsacZ+/bYBUPqhDQRKB8fQToxbqFn28/5gJvYF0I38IqD75XRNLsSlVv65iHgK+KyFlimSUi3ovHVmCZiMSLyGXABcPEkQF0AM0iMgH4nneBMaYG+DvwK7tSOVFEzvfZ9nmssuwvYZWpD+Up4APA53nvbgARuUhEzrDvQFqwLsC9w+xrII9hlalf5vPeauBTIjJfrKa5/w1sMMYcGGpHxphe4BngRyKSYZ/bu7CKnfzxG2C5iJxjfz9pInKliGT4rHOHiEyxz/l/YtXDDBfzX4FJIvJlEUm2YztnuGBEZI6IXGzvz431fY/mHKtACHXZlD7C5wH8A/ifAd7/ONYtfgLWL8XnsYoGGoH/81lvOVa5cxtWxeMC+/1FwE6sMvnHsH6J+9YRVPU7XiHwur2ffVhl4Qa7bgKrMvMRoA44Bjzbb/uHgHYg3Y/P/CpWZfUkn/dutD9Hu32M//M59ipg1SD7mu4bp8+5M9h1BD7nqQI4inUhnWK/P9X+zFMH2f94rAt/A9Yv8e8CcYOdxwG2vwzYCDRjJfQ/ABn2sgPAN4Fd9vJHsOtPhorZXna6fR6P2X8nd9vv3wM8PtD5AeZh/bBo9dlnYaj/D8TqQ+wvSKmoISLfBU4xxtwc6lgihYgcAD5jjHkl1LGo4IuGzjtK9bGLNT4N3BLqWJSKFFpHoKKGiHwWq8jk78aYdaGOR6lIoUVDSikV4/SOQCmlYlzE1RHk5uaa6dOnhzoMpZSKKJs3b240xuQNtCziEsH06dPZtGlTqMNQSqmIIiIHB1umRUNKKRXjNBEopVSM00SglFIxThOBUkrFOE0ESikV4zQRKKVUGFu1toKyisYT3iuraGTV2tFO/3EyTQRKKRXG5k3JYsXqLX3JoKyikRWrtzBvSlbAjhFx/QiUUiqWLJ4+gS9fOptPP7yJy06fxNp9DaxctoDS4tyAHUMTgVJKhZHuXg87jrh4s7KJDZVH2XTgKO1d1pw9z205wp0XzwpoEgBNBEop5bhVayuYNyXrhAt4WUUj26tc3HbuDHYcaebNyqO8WdnE5oPHOG5f+E/JT+ejC6cwIS2JR9Yf4BNLpvH4hkMsKc7ROwKllIok3nL+lcsWcNa08azecIif/GMvxXlp3PfKfjq6rQv/nPwMrjtrCufMzGHxjAnkpif31Qn86qaFlBbnsqQ4p29fgUoGmgiUUspB9a1u2jt7ed/sXD7x27cwGHo91rIej+H6s4tYMnMCi2fkMCEt6aTtt1e5TrjolxbnsnLZArZXuQKWCCJuPoJFixYZHXROKRVMQxXtLL+guO+941097Khysa2qma2Hm9l22MWR5g4A4uOECamJNLR1ccUZBfzwI6cPeOF3iohsNsYsGmiZ3hEopdQwfIt2SotzreKaJ7bwjcvn8PTGQ2w93MzWwy721bXS67F+XE8ZP44FU7P51LnTmV+UTZu7h7v+sI07L57F4xsOsae2JeCVvqPl6B2BiFwG3AfEAw8ZY+7ttzwLeByYipWUfmaM+f1Q+9Q7AqUim7+/rsNNWUUjn3/8bWblpbOtqpn4OKGzxyrjyUxJ4MyibBYUZXOm/chNTz5h25MSSYDL+YcTkjsCEYkH7gfeD1QBG0XkBWPMLp/V7gB2GWM+JCJ5wF4RecIY0+VUXEqp0Brw17X9Olz19HrYVd1Ce2cPmw8dIz8zmctOm8T8qdmcOSWbGblpiMig2wejnH8snCwaWgyUG2MqAUTkKeBqwDcRGCBDrDOYDhwFehyMSSkVYufMyOE7V87lc49u5qMLJ/OX7TVB/WU8UjurXdz9px3sOOIiMV74VOl0/rytmg+ePsnvmAe60yktzg2bz+xkIpgMHPZ5XQWc02+dlcALQDWQAVxvjPH035GI3A7cDjB16lRHglVK+cffop2eXg8Hjx5nf10b5fWt7K9vY39dGxUNbX1FKo+sP8j41ERe3V1PT69h8YwJpCTGB/0zDcTd3ct9r+7nwXWVpCUlkJ6cwIO3nEXprFzef1p+0It2nORYHYGIXAd80BjzGfv1LcBiY8wXfdb5GHAucBdQDLwMnGmMaRlsv1pHoFRo9S/fXrevgS8+uYVPlk4nToR99a2U17XxbmM7Xb3v/a6bnD2O2fnpzJ6YjiA8ufEQ84uyWV/ZBMZqSjkuMZ6lxTlcOCePC07JY1pOWsg+438+u4MDTce5flERBVkpLJ45IeLqNXyFqtVQFVDk83oK1i9/X58C7jVWNioXkXeBU4G3HIxLKTUGpcW5rLxxAZ99dDMpCXE0tVtVeve9uh8RmDohldkT07no1InMnpjO7Px0ivPSSUu2LjfeRPLrW87qqyO444m3+ez7ZlLX4ub1fQ28tqcegBm5aVxwSh4XzsljycwcHi474GhFs+t4Nz9as4tnNlUxLSeV1Z85h9JZA//iD6einbFyMhFsBGaLyAzgCHADsKzfOoeAS4A3RCQfmANUOhiTUmqMjjR38NC/3qW9s4f2Tlg0bTw3L5nGrInpzJqYPmzRzkAVp/fftJDtVS6+f/XpALzb2M7avfW8vq+BJ986xMNlB0hOiGPOpAz+79X9/ODq0/jowimsr2wKSEWzMYa/7ajhnhd2cex4F5+/sJgvXTI7bIqpnOZ089ErgF9gNR/9nTHmRyKyHMAYs0pECoGHgQJAsO4OHh9qn1o0pFRo9HoMj60/wE9f3Et3ryEhXrjt3BmsfuuQo2Xl7u5eNrx7lNf31rN2bwOVje0ApCXF09Xr4dqFU/jw/ELmTckmPXnkv21rXB185/l3eGV3PWdMzuLea8/gtMLADfEcLoYqGtKexUqpYe2tbeXuZ7ez5VAz86ZkcbDpOA/cvDAkbeIPNR3nu39+h9f3NZA1LgFXh9XQUARmT0xnvt2Of35RNnPyM0iIt6Zd6V/J7fEY/uuvu1i94RBxcfDVD8zhk6XT+9aPNtqzWCk1Kp09vdz/WjkPrK0gPTmBX1w/nxpXB2cWZYesTXxV83G2H3H19dB98JazSEyIY9vhZrYdbublXXU8s6kKgJTEOM6YnMWZU7JJTY7n84+/zQM3LSQvI5k7Vr/Nvro2zpicyf3LzmJqTqrjsYcrvSNQSg1o44Gj3P2n7VQ0tHPNgsl8+8q55Pj0lg0Ff3roGmM4fLSDLYeP2eP9NPNOdQtddpNVwbp7MAaWX1jM1z84Z8jOYNFCi4aUUn5rcXfz47/v4YkNh5icPY7//ugZXHBKXqjDAkY/PEVXj4e9ta1sPXyMJzYcYk9tK585bwbfvqokGGGHBS0aUkr55cWdtXz3z+/Q0NrJp8+bwV3vP6Wv2Wc4GG0P3aSEOM6YkkVrZzf1rZ19xUoXz50YNU1AxyI6a0WUGoFVayv6Jgb3KqtoZNXaihBF5J+xxN1/27oWN9etKuNzj21mfGoSz33hXL5zVUlYJYGx8i1GuusDc1i5bMEJk8LHMk0EKuZ5B0HzXhC8F4x5U8K7CaE37jf2N1Df6mbNjmq+8MTbTJ0wjvpW95CPqRPG8YUn3mbNjmqefOsQF/70n2w8cIzrFxXxly+ex5lF2aH+eAE31MBvsU7rCJSCvvHlP3BaPi/urOV+e1rAcNbZ08u9a/bw8PoDjPW/cUKc8ONrz+Das4qGX1lFJK0jUGoYpcW5zCnI4KmNh4mPgwder2B7lYvzZuVSUpBJXFz4tCrp7OnlmU1V/Oqf5dS43BRkpVDjcnPhnDwunZs/on29sruO1/c28PkLizUJxDBNBEoBL+2s5c2KJgqzU2hq6+Ldxjbe2G8VFY1PTWRpcQ7nzsrlvFm5TJ2QGpLmhl09Hv6w+TD3v1ZOtcvNwqnZfLJ0Or9eV9lX+Xn7+TP9vpMpq2hk+8vvtcdfWpwT9ndByhmaCFTMK6to5M4ntwDwyKcW09DWyYrVW/jVsgV09nr4d3kT/y5vZM2OWsAaRfO8WbmcOzuX0uIc/ri5ytGB0Lp7PfxxcxUrXyvnSHMH84uy+X/XziMxTljx5Htt6JcU5/jdw7d/+/uRbKuij9YRqJh3799389Ab73Ltwin8+GPzgJMv5MYYKhvbKStv5F/ljZRVNNHqtoY2KBo/jobWTu68ZDbXn13E3rrWgFxUu3s9PPt2Fb98rZyqY1Zv3q9cOpsLTslDRMY05WOkThepRk87lCk1hLue3srfdtTw+tcupCBrnF/b9HoM7xxx8a/yRv5d3shb7x6lx560XATOmGxdZOcWZFBSkMmM3LQBx7AZ6IL8xn5rxM13jrRw6Ohx5k3J4iuXnsKFc/JiogescoZWFis1iF3VLTy39QifO7/Y7yQAEB8nfZOU33HRLNzdvXzz2R08t+UIc/Iz6O41/PZflXT3WsnBO4Ty3EmZzC3IYG5BJqcWZJ4wf+/i6RP42Uv7eHBdBR5jJZPf3rqIi0+dqAlAOUoTgYppP3lxD5kpiXx+jMUhbx86xtp9DX0VryuXLWDRtAmU17exu6bFetS28PLuOp7e9N4MrpOzxzE9J43bHt5ISkI8zR3dTM9J5VtXlnDpXE0AKjg0EaiYVVbRyOt7G/jPK04lKzVxTPsZquK1pDCzb11jDHUtneyuaWGXN0HUtODu9uDu9nDlGQWsXLZAE4AKKk0EKiYZY7j373sozErhE0unj2lfQ/VY7V9ZLCJMykphUlYKF506EaBvqsabl0zjiQ2HWF/ZpC13VFBpIlAxac2OWrZXufjZdWeOeTrC0Q6EBu/dTXh7Mi/VZpwqBHSsIRVzuns9/PTFPczJz+CaBZNDGouOf6PCgd4RqJjz1MbDHGg6zu8+uYj4EA8dMZa7CaUCRe8IVExp7+zhvlf2s3jGBC6aMzHU4SgVFjQRqJjy0Bvv0tjWyd2Xn6otc5SyaSJQARXOk7w0tnXy4LoKLjttEgunjg91OEqFDU0EKqD6JnkpD79JXla+Vo67x8PXLpsT6lCUCitaWawCqrQ4l/tumM/Nv91AWlICnb0ePlk6nSnZqRhjQlYcc7CpnSc2HOT6s4sozksPSQxKhStNBCrgpuek4THQ2tlDSmIcD66r5MF1lRRmpbBkZg7nzJzAkpk5J43r7+SImP/z0j4S4uL48iWzx7QfpaKRo4lARC4D7gPigYeMMff2W/414CafWOYCecaYo07GpZz18q46AK6eX8gb+xv5r6tPpbO7lzcrj7J2XwPPbjkCQEFWCufMsJLCkpk5zJucdUJnKt+hG8ZiR5WLF7ZVs+KiWUzMTBnz51Mq2jg2DLWIxAP7gPcDVcBG4EZjzK5B1v8Q8BVjzMVD7VeHoQ5vZRWNfPbRTbR39vLKXedT39p5wsXdGENFQxvrK4+yobKJNyuP0tjWCUB+ZjLFeelsO9zMDWcX8dzW6oD0sL35oQ3srHax9usXkZky+jGFlIpkoRqGejFQboyptIN4CrgaGDARADcCTzoYjwqC7VUurppXyNMbD1OQNY5ZEzNOGHdHRJg1MYNZEzO4Zck0OzG0s+FdKylsqGyivauX3/77AGdNG89phWOrZH5jfwP/Km/kO1eVaBJQahBOthqaDBz2eV1lv3cSEUkFLgP+NMjy20Vkk4hsamhoCHigKnCWX1BMUnwcWeMSSUu2fmeUFucOWsZvJYZ0bjpnGr+8cQG/uH4+WeMSmTMpg80Hj1H6/17lN+sqcXf3jjgWj8caWG7K+HHcvGTqmD6XUtHMyUQwUPOQwcqhPgT8e7C6AWPMg8aYRcaYRXl5eQELUDmjxtVBQdbIy+LLKhpZ8eQWHrh5IS9++Xz++5rT6er18KM1u7n4Z6/zx81V9Hr8L8r8y/Zqdla38NUPzCE5YWwDyykVzZxMBFVAkc/rKUD1IOvegBYLRY0jzW4Ks/2f7cur/wBsy86ZxiO3LebGs4vIzUjmq3/YxhX3vcFre+oYrm6rs6eXn720l7kFmXz4zMJRfQ6lYoWTdQQbgdkiMgM4gnWxX9Z/JRHJAi4AbnYwFhVENa4OzpqWPeLthhqAzRjDmh21/PTFPdz28CYWz5jA3ZefOmgP4dUbDnH4aAeP3HYGcSEeWE6pcOfYHYExpgdYAbwI7AaeMcbsFJHlIrLcZ9VrgJeMMe1OxTIW4TxkQjg63tVD8/HuEc3/6w8R4cp5Bbx81wX84COnU9nQzkd/VcbyxzZT0dB2wrqt7m5++Vo5pcU5nD9bR/FUajiODjFhjFljjDnFGFNsjPmR/d4qY8wqn3UeNsbc4GQcY9E3ZEJF+A2ZEI6qm90AFGY7014/MT6OW5ZMY+3XLuSu95/CG/sb+MD/ruPq+//N37ZbJY+/WVfJ0fYurjhjEr9eV+lIHEpFE+1ZPIzS4lx+ecMCPv3wJuYXZbPjiIvvf7iExdMnhDq0sFTj6gCgMMB3BP2lJSdw5yWzWXbOVFa+Vs5jbx7gjtVb+Ps7tby6u54lMyfw85f3j7kzmlKxQBOBH/KzUujo7mV9ZRMA//GH7Xzz2XeYkZvGrInpfY/Z+enMyE3ra6Hi5JAJ4aq62U4Eo6gsHo3c9GTu+fBp3HbuDO5+djt/3V6DALtrWnng5oU6wYtSftBE4Id/7rGGTLhqXgHr9jVw4+KpIFBe18Y71S7WvFODtxFLnMC0nDSK89JJTYrnl6/u55tXnMoNZ0/lrQNHAzJkQjirbnYjAvlBHsphak4qqz+7hLuf3c5Tbx3m1qXTNAko5SdNBMMoq2jkF6/uB+Cu95/CsnOm9l3Mv3n5XADc3b1UNrSzv76Vivo2yhva2F/XxoGmdrp7Dd9+fid/2FTF4WMdUT8peY2rg7z0ZJISgj/CeVlFIy/trOPOi2fx+IZDLCnOiepzrVSgaCIYxvYqFx+aV8hTGw+Tn5nCzLz0E4ZMAEhJjKekMJOSwswTtu3u9XCw6Ti3/m4D26pc3HnxrKi/MFU3uykIUrGQL98B6kqLc1lSnHPCa6XU4HRimmEsv6CYlMR4MpIT/BoywVdifBz1rW6OHe8G4NH1B09qihptql0dTHaoxdBQ+ndGKy3O7UvYSqmhaSLwQ12Lm4mZySPezvsr9TtXlgBw4+KpJzRFjTbGGKqbOwLeh8Afyy8oPumXv78JW6lYp4nAD3UtbiaNYuwc76/U688uYnxqIvWtnVH9K7X5eDfubs+oxhlSSoWO1hH4oa6lk3NmjLzfgO+v0SUzc1hf0cjPrpsXtWXW1XYfgskhqCNQSo2e3hEMw+Mx1Le6yR/jr9zS4hyqXW4OHT0eoMjCj7dXcSgqi5VSo6eJYBjHjnfR3WvIzxh5HYGvpcU5AJRVNAUirLDU16s4BJXFSqnR00QwjNoW61fuWDtIFeelk5eRzPooTgTVzW4S44XctLElTaVUcGkiGEZ9iz2f7hiLhkSE0uIcyiqahh1LP1JVN3cwKStFh31WKsJoIhhGXYDuCACWzsyhsa3zpGGTo0WNq8PxweaUUoGniWAY3qKhvPSxF3d4WwtFaz1B9ShnJlNKhZYmgmHUtXSSm54UkLFziiaMY3L2OMrKoy8R9HoMtS1u7UOgVATSRDCM+hY3EzMCc3ETEZYW5/Dmu014RjAJeyRoaO2k12P0jkCpCKSJYBi1o+xVPJjS4hyaj3ezu7YlYPsMB0eatemoUpFKE8Ew6lo6yR/FOEOD8fYniLZmpO/1IdA7AqUijSaCIXT3emhq7wxY0RBAQdY4ZuSmRV8i8PYq1lZDSkUcTQRDaGjtxBgCWjQE1rhDG949Sk+vJ6D7DaUjzR2kJcWTmaLDVykVaTQRDOG9PgSB7SlbWpxDW2cP71RHTz1BjauDwuxxiGhnMqUijSaCIXgTQSCLhsC6IwCial6CGldoZiZTSo2dJoIh1NnDSwS6aCgvI5lT8tOjqp6gurmDQu1DoFRE0kQwhLoWNwlxwoTUpIDvu7Q4l00HjtHVE/n1BO7uXhrburTFkFIRShPBEGpb3EzMSHZkELUlM3Po6O5lW1VzwPcdbLUub4shvSNQKhI5mghE5DIR2Ssi5SJy9yDrXCgiW0Vkp4isdTKekapv6RzzqKODWTJzAiJExXATOjOZUpHNsUQgIvHA/cDlQAlwo4iU9FsnG/gV8GFjzGnAdU7FMxp1LW7yA1xR7JWdmsRphZlRUWFcozOTKRXRnLwjWAyUG2MqjTFdwFPA1f3WWQY8a4w5BGCMqXcwnhEL9PAS/S2dmcOWQ824u3sdO0YwVNvDS2jRkFKRyclEMBk47PO6yn7P1ynAeBF5XUQ2i8gnBtqRiNwuIptEZFNDQ4ND4Z7oeFcPre4eJga4D4Gv0uJcuno9bD54zLFjBEO1y01OWhIpifGhDkUpNQp+JQIR+ZOIXCkiI0kcA9Ww9h9yMwE4C7gS+CDwHRE55aSNjHnQGLPIGLMoLy9vBCGMnrfpqFNFQwBnz5hAfJxEfDPSGlcHBTrYnFIRy98L+wNYxTj7ReReETnVj22qgCKf11OA6gHW+Ycxpt0Y0wisA870MyZHeTuTOVk0lJ6cwLwpWRFfT1Dd3KFjDCkVwfxKBMaYV4wxNwELgQPAyyJSJiKfEpHEQTbbCMwWkRkikgTcALzQb50/A+8TkQQRSQXOAXaP5oMEmlPDS/RXWpzDtioXbZ09jh7HSTXNbm0xpFQE87uoR0RygE8CnwG2APdhJYaXB1rfGNMDrABexLq4P2OM2Skiy0Vkub3ObuAfwHbgLeAhY8w7o/40AdQ3vEQA5ioeytKZufR6DBsPHHX0OE5pcXfT2tmjFcVKRTC/hooUkWeBU4HHgA8ZY2rsRU+LyKbBtjPGrAHW9HtvVb/XPwV+OpKgg6GupZPUpHgykp0dTfOsaeNJio9jfUUTF82Z6OixnKBNR5WKfP5e5VYaY14baIExZlEA4wkbdS1u8jNTHB9Nc1xSPPOnZkdshfF7ncn0jkCpSOVv0dBcu/MXACIyXkS+4ExI4aHOHl4iGEqLc3in2oXreHdQjhdI7/Uh0DsCpSKVv4ngs8aYZu8LY8wx4LOORBQm6lo6HW0x5Ku0OBdj4M13I++uoKbZTXycBC1pKqUCz99EECc+ZST28BGBH5IzTBhjqLWLhoLhzKIsUhLjIrJ4qNrVQX5GMgnxOn6hUpHK3zqCF4FnRGQVVqew5VitfaKSq6Obrh5P0BJBckI8Z0+fEJmJoLlDK4qVinD+/oz7BvAa8HngDuBV4OtOBRVqfb2KHe5D4GvJzBz21rXS2NYZtGMGQo3LrfMQKBXh/O1Q5jHGPGCM+Zgx5lpjzK+NMZE9UtoQavs6kwWvJUxpsTV95ZuVkXNX4PEYKxFoHwKlIpq/Yw3NFpE/isguEan0PpwOLlT6hpcIYiI4Y3IW6ckJEVU81NTeRVePRzuTKRXh/C0a+j3WeEM9wEXAo1idy6JSvZ0I8oLYEiYhPo7FMyKrnqDG7kOgRUNKRTZ/E8E4Y8yrgBhjDhpj7gEudi6s0KptcZOdmhj0YZVLi3OobGzvm/ox3Hn7EGgiUCqy+ZsI3PYQ1PtFZIWIXANE3ngIfqpr6QxqsZDXkplWPcH6ysgYjbTaHl5CE4FSkc3fRPBlIBW4E2v+gJuBWx2KKeTqW9yODzY3kJKCTLLGJUbMPMY1rg6SE+IYnzrYALRKqUgwbD8Cu/PYx40xXwPagE85HlWI1ba4mTMpI+jHjYsTls7MYX2EtByqbraajjo9HpNSylnD3hHYzUTPkhj5397rMTS0dga16aivpcU5VB3r4PDR4yE5/khUuzoo1MHmlIp4/hYNbQH+LCK3iMhHvQ8nAwuVxrZOPMb5eQgG4+1PEAmzltU0u3WwOaWigL+JYALQhNVS6EP24yqnggqlUPQh8DVrYjq56clh34y0u9dDXat2JlMqGvg11pAxJurrBbxCMbyELxFhaXEOZRVNGGPCtvy9rsWNMdpiSKlo4O8MZb/HGmzuBMaY2wIeUYiFYniJ/kqLc/jLtmoqG9spzksPWRxDqdaZyZSKGv6OPvpXn+cpwDVAdeDDCb36FjdxArnpoRtff+lMbz1BU9gmghqdmUypqOFv0dCffF+LyJPAK45EFGJ1LW7yMpKJjwtdkcy0nFQKs1J4s6KJW5ZMC1kcQ+m7I9DKYqUi3mhnE5kNTA1kIOGitiV0TUe9RIQlxVZ/Ao/npBK5sFDd3EFmSgJpyf7eVCqlwpW/o4+2ikiL9wH8BWuOgqhTH8SZyYZSWpzL0fYu9ta1hjqUAdW4OrSiWKko4W/RUPC72YZIbYubRdPHhzoMltr9CdZXNDG3IDPE0ZzM26tYKRX5/L0juEZEsnxeZ4vIRxyLKkTc3b00H+8OWR8CX5OzxzEtJ5WyMO1PUO3q0HkIlIoS/tYRfM8Y4/K+MMY0A99zJKIQami1+hCEqldxf6XFOWx4t4neMKsnON7VQ/Pxbr0jUCpK+JsIBlrPnwHrLhORvSJSLiJ3D7D8QhFxichW+/FdP+NxRDj0IfBatbaCnLQkWt097Ky2cnBZRSOr1laEODLf4adDf56UUmPnbyLYJCI/F5FiEZkpIv8LbB5qA3vU0vuBy4ES4EYRKRlg1TeMMfPtx3+NKPoAC/XwEr7mTcni8Q2HAKs/QVlFIytWb2HelKxhtnRe38xk2nRUqajgbyL4ItAFPA08A3QAdwyzzWKg3BhTaYzpAp4Crh5toMEQ6uElfJUW5/KrmxYSJ7B6wyFWrN7CymULKC3ODXVo1OiENEpFFX9bDbUDJxXtDGMycNjndRVwzgDrLRWRbVg9lb9qjNk5wuMETF2Lm6SEOLLGhcdEK6XFucwtyGRndQtfvHhWWCQBgCPNHYiERxGaUmrs/G019LKIZPu8Hi8iLw632QDv9a/1fBuYZow5E/gl8Pwgx79dRDaJyKaGhgZ/Qh6VuhY3kzJTwmagt7KKRt5tbAfgsfUHw2Zo6hpXB3npySQljLY/olIqnPj7PznXbikEgDHmGMPPWVwFFPm8nkK/8YmMMS3GmDb7+RogUURO+tlrjHnQGLPIGLMoLy/Pz5BHrq7FHRbFQkBfncDXL5sDwGfeN4MVq7eERTKocbl1sDmlooi/icAjIn1DSojIdAYYjbSfjcBsEZkhIknADcALviuIyCTvzGcistiOJ2QN5+vCYHgJr+1VLlYuW8DHzipCBIyBlcsWsL3KNfzGDjvS3KHzECgVRfwdKOZbwL9EZK39+nzg9qE2MMb0iMgK4EUgHvidMWaniCy3l68CPgZ8XkR6sCqgbzDGhKTRvDGGuhY3F5863I1OcCy/oLjv+fScNHbVtPDFS2aHvJ7AGENNs5uL5oTHeVJKjZ2/lcX/EJFFWBf/rcCfsS7cw223BljT771VPs9XAitHEK9jWjt7ON7VGzZFQ77mFmSws7ol1GEA4OropqO7V3sVKxVF/J2Y5jPAl7DK+bcCS4D1WFNXRoX6MOpM1l9JQSZrdtTS6u4mIyW0LZqONHvnIdA6AqWihb91BF8CzgYOGmMuAhYAzjXfCYH3+hCEYSIotAad21Mb+pFIa3RmMqWijr+JwG2McQOISLIxZg8wx7mwgq/WFc53BFZv4l1hUDxU3derOPzOk1JqdPytLK6y+xE8D7wsIseIsqkq61q9iSD86gjyM5OZkJbE7powSATNbhLjJaRTeSqlAsvfyuJr7Kf3iMg/gSzgH45FFQL1LZ1kpCSQmhR+M26JCCUFmewKg0RQ4+pgUlYKcSGcylMpFVgj7hpqjFlrjHnBHj8oatS6wmNmssGUFGayp7aVnl5PSOOobu7QeYqVijI6RoCtrtUdFqOODmZuQQZdPR4q7SEnQqW62a0thpSKMpoIbHUuNxPDsH7AKxwqjHs9Vqc77UOgVHTRRAB4PIb61s6wviOYmZdGUkJcSOsJGlo76fEYHX5aqSijiQA4eryLHo8J6zqCxPg45uRnhLTlUF/TUZ2ZTKmoookA3z4E4Vs0BFYP413VLYRoOCaq7V7FWlmsVHTRRADUt4ZvZzJfJYWZNLV3Ud/aGZLj68xkSkUnTQSE9/ASvuYWWENNhKrCuNrVQVpSPJkp4dfXQik1epoIsIqGRCAvI7yLhk4tyAAIWYVxdXMHBdnjwmYGN6VUYGgiwCoayklLJjE+vE9HZkoiUyekhuyOoMbl1mIhpaJQeF/5gsSamSy87wa8SgoyQ9ZyqLrZrYPNKRWFNBFgFQ2Fcx8CXyWFmbzb1E57Z09Qj9vZ00tjW6feESgVhTQRYBUNTYyURFCQiTHBn5vA28RWexUrFX1iPhF09XhobOuKmKKhufYkNcGuMK7WpqNKRa2YTwQNbVbT0UgpGirMSiFrXGLQK4y9nck0ESgVfWI+EdSF8VzFAwnV3AQ1Lm+v4sg4T0op/2kisMu+w3nk0f5KCjPZW9tCryd4Q00caXYzIS2JlMT4oB1TKRUcmgjsO4JIKRoCq8LY3e3h3SDOTVDj6tDB5pSKUpoIWjtJjBfGpyaFOhS/lYSgwrim2a2DzSkVpTQRuNxMzIisOXiL89JJjJegVhhXN3fozGRKRSlNBK3uiGk66pWUEMfsiRlBuyNodXfT2tmjFcVKRSlHE4GIXCYie0WkXETuHmK9s0WkV0Q+5mQ8Awn3SesHU1KYGbQ7ghpvZzK9I1AqKjmWCEQkHrgfuBwoAW4UkZJB1vsx8KJTsQylvqUzMhNBQSaNbZ19cyk46Yjdh2CyVhYrFZWcvCNYDJQbYyqNMV3AU8DVA6z3ReBPQL2DsQyovbOH1s6eyEwEdoXx7hrnh5rwTkijlcVKRScnE8Fk4LDP6yr7vT4iMhm4Blg11I5E5HYR2SQimxoaGgIW4HudySKrjgCCO0lNdXMHcQITw3y+BqXU6DiZCAZqhtO/B9QvgG8YY3qH2pEx5kFjzCJjzKK8vLxAxdc3M1kk9SHwyhqXyOTscUGpMK52dTApM4WEMJ+vQSk1Ok7OOVgFFPm8ngJU91tnEfCUPeNVLnCFiPQYY553MK4+3vL1SBl5tD+rwtjl+HFqmt1aUaxUFHPyJ95GYLaIzBCRJOAG4AXfFYwxM4wx040x04E/Al8IVhKA94ZWjsSiIbAqjN9tbKeja8gbqjGrdnXoYHNKRTHHEoExpgdYgdUaaDfwjDFmp4gsF5HlTh13JOpaOklLiicjJTHUoYxKSWEmHgN765yrMDbGWFNUah8CpaKWk0VDGGPWAGv6vTdgxbAx5pNOxjIQqzNZ5F7gSnwqjOcXZTtyjKb2Lrp6PNqZTKkoFtO1f3Uud0SNOtrflPHjyEhJYFeNc/UEOg+BUtEvthNBa+TMVTwQEWFugbM9jHVmMqWiX8wmAmMMdRHaq9hXSUEme2pb8Tg0N4H3jkCLhpSKXjGbCJqPd9PV44n8RFCYyfGuXg4ePe7I/mtcHSQnxDEhLXKG6VZKjUzMJoK61siaonIwJQ73MK52uSnMHofd10MpFYViNhFEeh8Cr9n56STEiWMVxtXNOjOZUtEuZhNBvT28RKTfESQnxDNrYrpjdwQ6M5lS0S9mE4F3wLlIbj7qVVKQ6ciYQ929HupbtTOZUtEuZhNBbYub8amJJCfEhzqUMSspzKSupZOmts6A7reuxY3HaNNRpaJdzCaCaGg66uWtMA703AQ6M5lSsSGGE0FkDy/hq29uggBXGPf1KtaiIaWiWkwngkjuVexrfFoShVkpAa8w9vYq1jsCpaJbTCaCnl4PjW2dEd901FdJYeArjGtcHWSmJJCe7OjYhEqpEIvJRNDY1oXHRO6ENAMpKcikoqEdd3fg5iaw+hDo3YBS0S4mE4G36Wi0FA2BVU/Q6zHsC+DcBNXNbk0ESsWAmE4E0VJZDFbREMDuABQPrVpbQVlFIzWujr7B5soqGlm1tmLM+1ZKhZ8YTwTRU0dQND6V9OSEgFQYz5uSxR1PvM2x490UZo+jrKKRFau3MG9KVgAiVUqFmxhNBJ3Exwk56dGTCOLihLkFGQGpMC4tzuVbV84FYNvhZlas3sLKZQsoLc4d876VUuEnRhOBm7z0ZOLjomtEzZKCTHbXBGZuggON1rDWL+2q4+ZzpmoSUCqKxWQiqG1xR1WxkFdJYSZtnT0cPja2uQnePnSM+/9ZTlJCHHdePIvHNxyirKIxQFEqpcJNTCaC+igaXsLX3ADMTXC8q4cvPP42IvDATQu56wNzWLlsAStWb9FkoFSUislEUBtFw0v4OiU/g/g4GVPLoXv/vofaFjf/ecVcLpmbD1h1BiuXLWB7lTNzHiilQivmuoy6u3txdXQzKQrHz0lJjKc4L23UFcbr9jXw6PqDfPq8GXzmfTNPWFZanKv1BEpFqZi7I/BOSDMxI/rqCMCem2AURUOu4918/Y/bmTUxna99cI4DkSmlwlXMJYLaKOxM5qukMJNql5tj7V0j2u57L7xDY1sn//vx+aQkRv4cDUop/8VcIugbXiIKi4YASgqsTl8jqSf42/Yant9azZ2XzOYM7TSmVMxxNBGIyGUisldEykXk7gGWXy0i20Vkq4hsEpHznIwHfHoVZ0RnIphbkAHgdz1BfYubbz2/gzOLsvnChcVOhqaUClOOVRaLSDxwP/B+oArYKCIvGGN2+az2KvCCMcaIyDzgGeBUp2ICKxEkJ8SROS4668lz0pPJz0z2KxEYY/jGn7bT0dXLzz9+JgnxMXeDqJTC2TuCxUC5MabSGNMFPAVc7buCMabNGOPtBpsGjL1L7DDqWjqZlJWCSHT1Kvblb4XxUxsP88+9DXzz8lMpzksPQmRKqXDkZCKYDBz2eV1lv3cCEblGRPYAfwNuG2hHInK7XXS0qaGhYUxB1ba4o7ZYyKukMJPy+jY6ewafm+BQ03F+8NddnDsrh08snR684JRSYcfJRDDQT+6TfvEbY54zxpwKfAT4wUA7MsY8aIxZZIxZlJeXN6ag6lvc5EdpRbFXSUEWPR7D/rq2AZf3egx3PbOV+Djhpx87k7goG3NJKTUyTiaCKqDI5/UUoHqwlY0x64BiEXGs15IxhrqWTvKjtA+Bl3dugsHqCX7zRiWbDh7j+x8+TSeeUUo5mgg2ArNFZIaIJAE3AC/4riAis8QurBeRhUAS0ORUQC3uHjq6e6O2D4HXtAmppCbFD1hPsLumhZ+/tI/LT5/ENQtOKqlTSsUgx5rOGGN6RGQF8CIQD/zOGLNTRJbby1cB1wKfEJFuoAO43qfyOODqvU1Ho7xoKC5OOHVSxkl9CTp7evnK01vJHJfIDz9yelRXmCul/OdoG0pjzBpgTb/3Vvk8/zHwYydj8FVnDy8R7UVDYBUP/XlrNcaYvgv+fa/sZ09tKw99YlFUTcqjlBqbmGo4Hu3DS/gqKcii1d1D1bEOADYfPMqqtRVcv6iIS0vyQxydUiqcxFQiiMZJ6wfjW2Hc3tnDXc9sozB7HN++am6II1NKhZvo7F47iPoWN5kpCYxLiu5B1VatreDU/AzixJqkZt2+Bg42HWfZ4qlkpCSGOjylVJiJqUQQrRPS9DdvShYrVm9hUmYKf9xcxZHmDlIS4rjqzIJQh6aUCkMxVjTUGbWjjvryzijW2NbFkeYO4gVW3XKWTiyjlBpQjCUCNxOjfHgJr9LiXJbMnADAdYuKuHDOxBBHpJQKVzGTCDweQ31rJ5OyYqPZZFlFIzuOuPj0eTN4aVedTjyvlBpU1CeCVWsrKKtopKm9i16PIT8zhbKKRlatrQh1aI4pq2hkxeot3H/TQr5zVQkrly1gxeotmgyUUgOK+kTgrTh9eVctAMfau1mxegvzongmru1VLlYuW9BXJ+CtM9he5QpxZEqpcCQOjujgiEWLFplNmzaNaJuyikZuf3QzbZ09ZKYkaMWpUirmiMhmY8yigZZF/R0BWL+ILzvd6k173aIpmgSUUspHTCSCsopGXtvTwJ0Xz+K5LdVaVq6UUj6iPhF4K05XLlvAXR+YoxWnSinVT9QnAq04VUqpocVEZbFSSsW6mK8sVkopNThNBEopFeM0ESilVIzTRKCUUjFOE4FSSsW4iGs1JCINwMFRbp4LhGMHgnCNC8I3No1rZDSukYnGuKYZY/IGWhBxiWAsRGTTYM2nQilc44LwjU3jGhmNa2RiLS4tGlJKqRiniUAppWJcrCWCB0MdwCDCNS4I39g0rpHRuEYmpuKKqToCpZRSJ4u1OwKllFL9aCJQSqkYF5WJQEQuE5G9IlIuIncPsFxE5P/s5dtFZGEQYioSkX+KyG4R2SkiXxpgnQtFxCUiW+3Hd52Oyz7uARHZYR/zpKFdQ3S+5vich60i0iIiX+63TtDOl4j8TkTqReQdn/cmiMjLIrLf/nf8INsO+ffoQFw/FZE99nf1nIhkD7LtkN+7A3HdIyJHfL6vKwbZNtjn62mfmA6IyNZBtnXkfA12bQjq35cxJqoeQDxQAcwEkoBtQEm/da4A/g4IsATYEIS4CoCF9vMMYN8AcV0I/DUE5+wAkDvE8qCfrwG+01qsDjEhOV/A+cBC4B2f934C3G0/vxv48Wj+Hh2I6wNAgv38xwPF5c/37kBc9wBf9eO7Dur56rf8f4DvBvN8DXZtCObfVzTeESwGyo0xlcaYLuAp4Op+61wNPGosbwLZIlLgZFDGmBpjzNv281ZgNzDZyWMGUNDPVz+XABXGmNH2KB8zY8w64Gi/t68GHrGfPwJ8ZIBN/fl7DGhcxpiXjDE99ss3gSmBOt5Y4vJT0M+Xl4gI8HHgyUAdz8+YBrs2BO3vKxoTwWTgsM/rKk6+4PqzjmNEZDqwANgwwOKlIrJNRP4uIqcFKSQDvCQim0Xk9gGWh/R8ATcw+H/OUJwvr3xjTA1Y/5mBiQOsE+pzdxvW3dxAhvvenbDCLrL63SBFHaE8X+8D6owx+wdZ7vj56ndtCNrfVzQmAhngvf5tZP1ZxxEikg78CfiyMaal3+K3sYo/zgR+CTwfjJiAc40xC4HLgTtE5Px+y0N5vpKADwN/GGBxqM7XSITy3H0L6AGeGGSV4b73QHsAKAbmAzVYxTD9hex8ATcy9N2Ao+drmGvDoJsN8N6Iz1c0JoIqoMjn9RSgehTrBJyIJGJ90U8YY57tv9wY02KMabOfrwESRSTX6biMMdX2v/XAc1i3m75Ccr5slwNvG2Pq+i8I1fnyUectIrP/rR9gnVD9rd0KXAXcZOzC5P78+N4DyhhTZ4zpNcZ4gN8McrxQna8E4KPA04Ot4+T5GuTaELS/r2hMBBuB2SIyw/41eQPwQr91XgA+YbeGWQK4vLdgTrHLH38L7DbG/HyQdSbZ6yEii7G+nyaH40oTkQzvc6yKxnf6rRb08+Vj0F9poThf/bwA3Go/vxX48wDr+PP3GFAichnwDeDDxpjjg6zjz/ce6Lh865WuGeR4QT9ftkuBPcaYqoEWOnm+hrg2BO/vK9A14OHwwGrlsg+rNv1b9nvLgeX2cwHut5fvABYFIabzsG7ZtgNb7ccV/eJaAezEqvl/EygNQlwz7eNts48dFufLPm4q1oU9y+e9kJwvrGRUA3Rj/Qr7NJADvArst/+dYK9bCKwZ6u/R4bjKscqNvX9nq/rHNdj37nBcj9l/P9uxLlYF4XC+7Pcf9v5d+awblPM1xLUhaH9fOsSEUkrFuGgsGlJKKTUCmgiUUirGaSJQSqkYp4lAKaVinCYCpZSKcZoIlAoisUZM/Wuo41DKlyYCpZSKcZoIlBqAiNwsIm/ZY8//WkTiRaRNRP5HRN4WkVdFJM9ed76IvCnvjf8/3n5/loi8Yg+K97aIFNu7TxeRP4o1Z8AT3t7RSoWKJgKl+hGRucD1WIOMzQd6gZuANKxxjxYCa4Hv2Zs8CnzDGDMPq+es9/0ngPuNNSheKVaPVrBGl/wy1pjzM4FzHf5ISg0pIdQBKBWGLgHOAjbaP9bHYQ345eG9QckeB54VkSwg2xiz1n7/EeAP9rg0k40xzwEYY9wA9v7eMvaYNmLNhjUd+Jfjn0qpQWgiUOpkAjxijPnmCW+KfKffekONzzJUcU+nz/Ne9P+hCjEtGlLqZK8CHxORidA3d+w0rP8vH7PXWQb8yxjjAo6JyPvs928B1hprPPkqEfmIvY9kEUkN5odQyl/6S0Spfowxu0Tk21izUcVhjVR5B9AOnCYimwEXVj0CWEMEr7Iv9JXAp+z3bwF+LSL/Ze/juiB+DKX8pqOPKuUnEWkzxqSHOg6lAk2LhpRSKsbpHYFSSsU4vSNQSqkYp4lAKaVinCYCpZSKcZoIlFIqxmkiUEqpGPf/AYq6Oa09dWK8AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_accuracies(history)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "immediate-nirvana",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@torch.no_grad()\n",
+    "def test(model, test_loader):\n",
+    "    model.eval()\n",
+    "    test_loss = 0.0\n",
+    "    num_correct = 0\n",
+    "    \n",
+    "    preds = torch.tensor([])\n",
+    "    targets = torch.tensor([])\n",
+    "    for batch_idx, batch in enumerate(test_loader):\n",
+    "        images, labels = batch\n",
+    "        \n",
+    "        outputs = model(images)\n",
+    "        loss = model.test_step(batch)\n",
+    "        _, pred = torch.max(outputs, dim=1)\n",
+    "        \n",
+    "        preds = torch.cat((preds, pred), dim=0)\n",
+    "        targets = torch.cat((targets, labels), dim=0)\n",
+    "        \n",
+    "        test_loss = test_loss + ((1/(batch_idx+1)) * (loss.data - test_loss))\n",
+    "    \n",
+    "    for i in range(len(preds)):\n",
+    "        if preds[i] == targets[i]:\n",
+    "            num_correct += 1\n",
+    "        \n",
+    "    print('Test accuracy:', num_correct/len(preds))\n",
+    "    print('Test loss:', test_loss.item())\n",
+    "    return targets, preds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "graduate-knock",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cpu');\n",
+    "test_loader = DeviceDataLoader(test_loader, device);\n",
+    "model = to_device(model, device);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aboriginal-vienna",
+   "id": "directed-vienna",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    targets, preds = test(model, test_loader)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "described-northern",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
- Added `ModelBase` class which extends the `nn.Module` instead of having it on each model
- Replaced `use_cuda` variable with a more sophisticated technique with `get_default_device`, `to_device` functions, and `DeviceDataLoader` classs
- Changed `train`, `evaluate`, and `test` functions accordingly